### PR TITLE
Support nested data

### DIFF
--- a/packages/react-bootstrap-table2/src/body.js
+++ b/packages/react-bootstrap-table2/src/body.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import _ from './utils';
 import Row from './row';
 
 const Body = ({ columns, data, keyField }) => (
@@ -8,7 +9,7 @@ const Body = ({ columns, data, keyField }) => (
     {
       data.map((row, index) => (
         <Row
-          key={ row[keyField] }
+          key={ _.get(row, keyField) }
           row={ row }
           rowIndex={ index }
           columns={ columns }

--- a/packages/react-bootstrap-table2/src/cell.js
+++ b/packages/react-bootstrap-table2/src/cell.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import _ from './utils';
 
 const Cell = ({ row, rowIndex, column }) => {
-  let content = row[column.dataField];
+  let content = _.get(row, column.dataField);
   if (column.formatter) {
     content = column.formatter(content, row, rowIndex, column.formatExtraData);
   }

--- a/packages/react-bootstrap-table2/src/row.js
+++ b/packages/react-bootstrap-table2/src/row.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import _ from './utils';
 import Cell from './cell';
 
 const Row = ({ row, rowIndex, columns }) => (
@@ -9,7 +10,7 @@ const Row = ({ row, rowIndex, columns }) => (
       columns.map(column =>
         (
           <Cell
-            key={ row[column.dataField] }
+            key={ _.get(row, column.dataField) }
             row={ row }
             rowIndex={ rowIndex }
             column={ column }

--- a/packages/react-bootstrap-table2/src/utils.js
+++ b/packages/react-bootstrap-table2/src/utils.js
@@ -1,0 +1,18 @@
+/* eslint no-empty: 0 */
+
+function get(target, field) {
+  const pathArray = [field]
+    .join('.')
+    .replace(/\[/g, '.')
+    .replace(/\]/g, '')
+    .split('.');
+  let result;
+  try {
+    result = pathArray.reduce((curr, path) => curr[path], target);
+  } catch (e) {}
+  return result;
+}
+
+export default {
+  get
+};

--- a/packages/react-bootstrap-table2/test/utils.test.js
+++ b/packages/react-bootstrap-table2/test/utils.test.js
@@ -1,0 +1,24 @@
+import _ from '../src/utils';
+
+describe('Utils', () => {
+  describe('get', () => {
+    const data = {
+      name: 'A',
+      address: {
+        road: 'BCD',
+        postal: '1234-12345',
+        city: {
+          name: 'B'
+        }
+      }
+    };
+
+    it('should return correct data', () => {
+      expect(_.get(data, 'name')).toEqual(data.name);
+      expect(_.get(data, 'address.road')).toEqual(data.address.road);
+      expect(_.get(data, 'address.city.name')).toEqual(data.address.city.name);
+      expect(_.get(data, 'address.notExist')).toEqual(undefined);
+      expect(_.get(data, 'address.not.exist')).toEqual(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Implement https://github.com/react-bootstrap-table/react-bootstrap-table2/issues/14

it's able to configure the `dataField` to access the nested data, 
```js
const columns = [{
  dataField: 'id',
  text: 'Person ID'
}, {
  dataField: 'nest.address.road',
  text: 'Road Name'
}, {
  dataField: 'nest.postal',
  text: 'Postal'
}];
```
Issue related with https://github.com/AllenFang/react-bootstrap-table/issues/50
`react-bootstrap-table2` will start support nested data from `v0.0.1`.