### PR TITLE
Implement formatter for header column

### DIFF
--- a/packages/react-bootstrap-table2/src/header-cell.js
+++ b/packages/react-bootstrap-table2/src/header-cell.js
@@ -5,9 +5,10 @@ import _ from './utils';
 
 
 const HeaderCell = ({ column, index }) => {
-  const { headerTitle, text, headerAlign } = column;
+  const { headerTitle, text, headerAlign, headerFormatter } = column;
   const attrs = {};
   const headerStyle = {};
+  const children = headerFormatter ? headerFormatter(column, index) : text;
 
   if (headerTitle) {
     attrs.title = _.isFunction(headerTitle) ? headerTitle(column, index) : text;
@@ -19,9 +20,10 @@ const HeaderCell = ({ column, index }) => {
 
   attrs.style = headerStyle;
 
+
   return (
     <th { ...attrs }>
-      { column.text }
+      { children }
     </th>
   );
 };
@@ -30,6 +32,7 @@ HeaderCell.propTypes = {
   column: PropTypes.shape({
     dataField: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
+    headerFormatter: PropTypes.func,
     formatter: PropTypes.func,
     formatExtraData: PropTypes.any,
     classes: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/packages/react-bootstrap-table2/test/header-cell.test.js
+++ b/packages/react-bootstrap-table2/test/header-cell.test.js
@@ -119,4 +119,32 @@ describe('HeaderCell', () => {
       });
     });
   });
+
+  describe('when column.headerFormatter prop is defined', () => {
+    const column = {
+      dataField: 'id',
+      text: 'ID'
+    };
+    const formatterResult = (<h3>{ column.text }</h3>);
+    const formatter = sinon.stub()
+      .withArgs(column, index)
+      .returns(formatterResult);
+    column.headerFormatter = formatter;
+
+    beforeEach(() => {
+      wrapper = shallow(<HeaderCell column={ column } index={ index } />);
+    });
+
+    afterEach(() => { formatter.reset(); });
+
+    it('should render successfully', () => {
+      expect(wrapper.length).toBe(1);
+      expect(wrapper.contains(formatterResult)).toBe(true);
+    });
+
+    it('should call custom headerFormatter correctly', () => {
+      expect(formatter.callCount).toBe(1);
+      expect(formatter.calledWith(column, index)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Implement #26 

```js
column.headerFormatter = (column, colIndex) =>
    (<h3>{ column.text }</h3>)
```