### PR TITLE
yarn install for CI mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ node_js:
   - "6"
 
 cache:
-  directories:
-    - node_modules
+  yarn: true
 
 branches:
   only:
@@ -14,8 +13,8 @@ branches:
   # - master 
   - develop
 
-# before_install:
-#   - curl -o- -L https://yarnpkg.com/install.sh | bash -s
-#   - export PATH="$HOME/.yarn/bin:$PATH"
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s
+  - export PATH="$HOME/.yarn/bin:$PATH"
 
-# install: yarn --frozen-lockfile
+install: yarn install --pure-lockfile --ignore-scripts


### PR DESCRIPTION
The PR is a little patch to ignore unnecessary `postinstall` in `CI mode`. Besides, install node modules in yarn.

* ref: [#61](https://github.com/react-bootstrap-table/react-bootstrap-table2/pull/61)