### PR TITLE
No need BootstrapTableful anymore

### DIFF
--- a/docs/row-selection.md
+++ b/docs/row-selection.md
@@ -26,7 +26,7 @@ Specifying the selection way for `single(radio)` or `multiple(checkbox)`. If `ra
 const selectRowProp = {
   mode: 'radio' // single row selection
 };
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -39,7 +39,7 @@ const selectRowProp = {
   mode: 'checkbox' // multiple row selection
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }

--- a/packages/react-bootstrap-table2-example/examples/basic/borderless-table.js
+++ b/packages/react-bootstrap-table2-example/examples/basic/borderless-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -18,7 +18,7 @@ const columns = [{
 }];
 
 const sourceCode = `\
-<BootstrapTableful
+<BootstrapTable
   keyField="id"
   data={ products }
   columns={ columns }
@@ -28,7 +28,7 @@ const sourceCode = `\
 
 export default () => (
   <div>
-    <BootstrapTableful
+    <BootstrapTable
       keyField="id"
       data={ products }
       columns={ columns }

--- a/packages/react-bootstrap-table2-example/examples/basic/caption-table.js
+++ b/packages/react-bootstrap-table2-example/examples/basic/caption-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -31,17 +31,17 @@ const columns = [{
 
 const CaptionElement = () => <h3 style={{ borderRadius: '0.25em', textAlign: 'center', color: 'purple', border: '1px solid purple', padding: '0.5em' }}>Component as Header</h3>;
 
-<BootstrapTableful keyField="id" data={ products } caption="Plain text header" columns={ columns } />
+<BootstrapTable keyField="id" data={ products } caption="Plain text header" columns={ columns } />
 
-<BootstrapTableful keyField="id" data={ products } caption={<CaptionElement />} columns={ columns } />
+<BootstrapTable keyField="id" data={ products } caption={<CaptionElement />} columns={ columns } />
 `;
 
 const Caption = () => <h3 style={{ borderRadius: '0.25em', textAlign: 'center', color: 'purple', border: '1px solid purple', padding: '0.5em' }}>Component as Header</h3>;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } caption="Plain text header" columns={ columns } />
-    <BootstrapTableful keyField="id" data={ products } caption={<Caption />} columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } caption="Plain text header" columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } caption={<Caption />} columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/basic/index.js
+++ b/packages/react-bootstrap-table2-example/examples/basic/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -29,12 +29,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/basic/no-data-table.js
+++ b/packages/react-bootstrap-table2-example/examples/basic/no-data-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 
 const columns = [{
@@ -15,7 +15,7 @@ const columns = [{
 }];
 
 const sourceCode = `\
-<BootstrapTableful keyField='id' data={ [] } columns={ columns } noDataIndication="Table is Empty" />
+<BootstrapTable keyField='id' data={ [] } columns={ columns } noDataIndication="Table is Empty" />
 
 // Following is more customizable example
 
@@ -23,12 +23,12 @@ function indication() {
   // return something here
 }
 
-<BootstrapTableful keyField='id' data={ [] } columns={ columns } noDataIndication={ indication } />
+<BootstrapTable keyField='id' data={ [] } columns={ columns } noDataIndication={ indication } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ [] } columns={ columns } noDataIndication="Table is Empty" />
+    <BootstrapTable keyField="id" data={ [] } columns={ columns } noDataIndication="Table is Empty" />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/basic/striped-hover-condensed-table.js
+++ b/packages/react-bootstrap-table2-example/examples/basic/striped-hover-condensed-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -18,7 +18,7 @@ const columns = [{
 }];
 
 const sourceCode = `\
-<BootstrapTableful
+<BootstrapTable
   keyField="id"
   data={ products }
   columns={ columns }
@@ -30,7 +30,7 @@ const sourceCode = `\
 
 export default () => (
   <div>
-    <BootstrapTableful
+    <BootstrapTable
       keyField="id"
       data={ products }
       columns={ columns }

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/blur-to-save-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/blur-to-save-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -34,7 +34,7 @@ const cellEdit = {
   blurToSave: true
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -48,7 +48,7 @@ const cellEdit = {
 };
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-hooks-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-hooks-table.js
@@ -2,7 +2,7 @@
 /* eslint no-console: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -37,7 +37,7 @@ const cellEdit = {
   afterSaveCell: (oldValue, newValue, row, column) => { console.log('After Saving Cell!!'); }
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -52,7 +52,7 @@ const cellEdit = {
 };
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-validator-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-validator-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 /* eslint no-unused-vars: 0 */
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -64,7 +64,7 @@ const cellEdit = {
   blurToSave: true
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -79,7 +79,7 @@ const cellEdit = {
 export default () => (
   <div>
     <h3>Product Price should bigger than $2000</h3>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-with-promise-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-with-promise-table.js
@@ -2,7 +2,7 @@
 /* eslint arrow-body-style: 0 */
 import React, { Component } from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator, sleep } from 'utils/common';
 
@@ -38,7 +38,7 @@ class CellEditWithPromise extends Component {
 
     return (
       <div>
-        <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+        <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
         <Code>{ sourceCode }</Code>
       </div>
     );
@@ -64,7 +64,7 @@ class CellEditWithPromise extends Component {
 
     return (
       <div>
-        <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+        <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
         <Code>{ sourceCode }</Code>
       </div>
     );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-with-redux-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-with-redux-table.js
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import thunk from 'redux-thunk';
 import { Provider, connect } from 'react-redux';
 import { createStore, applyMiddleware } from 'redux';
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -64,7 +64,7 @@ class CellEditWithRedux extends Component {
 
     return (
       <div>
-        <BootstrapTableful keyField="id" data={ this.props.data } columns={ columns } cellEdit={ cellEdit } />
+        <BootstrapTable keyField="id" data={ this.props.data } columns={ columns } cellEdit={ cellEdit } />
         <Code>{ sourceCode }</Code>
       </div>
     );
@@ -157,7 +157,7 @@ class CellEditWithRedux extends Component {
 
     return (
       <div>
-        <BootstrapTableful keyField="id" data={ this.props.data } columns={ columns } cellEdit={ cellEdit } />
+        <BootstrapTable keyField="id" data={ this.props.data } columns={ columns } cellEdit={ cellEdit } />
         <Code>{ sourceCode }</Code>
       </div>
     );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/cell-level-editable-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/cell-level-editable-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -36,7 +36,7 @@ const cellEdit = {
   mode: 'click'
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -49,7 +49,7 @@ const cellEdit = {
 };
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/click-to-edit-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/click-to-edit-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -33,7 +33,7 @@ const cellEdit = {
   mode: 'click'
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -46,7 +46,7 @@ const cellEdit = {
 };
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/column-level-editable-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/column-level-editable-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -37,7 +37,7 @@ const cellEdit = {
   blurToSave: true
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -51,7 +51,7 @@ const cellEdit = {
 };
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/dbclick-to-edit-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/dbclick-to-edit-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -33,7 +33,7 @@ const cellEdit = {
   mode: 'dbclick'
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -46,7 +46,7 @@ const cellEdit = {
 };
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/row-level-editable-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/row-level-editable-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -36,7 +36,7 @@ const cellEdit = {
   nonEditableRows: () => [0, 3]
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -51,7 +51,7 @@ const cellEdit = {
 };
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/column-align-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-align-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -40,12 +40,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/column-attrs-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-attrs-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -34,12 +34,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/column-class-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-class-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -40,12 +40,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/column-event-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-event-table.js
@@ -2,7 +2,7 @@
 /* eslint no-alert: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -37,13 +37,13 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
     <h3>Try to Click on Product ID columns</h3>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/column-format-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-format-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -53,7 +53,7 @@ const columns = [
   formatter: priceFormatter
 }];
 
-<BootstrapTableful
+<BootstrapTable
   keyField="id"
   data={ products }
   columns={ columns }
@@ -62,7 +62,7 @@ const columns = [
 
 export default () => (
   <div>
-    <BootstrapTableful
+    <BootstrapTable
       keyField="id"
       data={ products }
       columns={ columns }

--- a/packages/react-bootstrap-table2-example/examples/columns/column-format-with-extra-data-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-format-with-extra-data-table.js
@@ -1,7 +1,7 @@
 /* eslint no-console: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -51,7 +51,7 @@ const columns = [
     down: 'glyphicon glyphicon-chevron-down'
 }];
 
-<BootstrapTableful
+<BootstrapTable
   keyField="id"
   data={ products }
   columns={ columns }
@@ -60,7 +60,7 @@ const columns = [
 
 export default () => (
   <div>
-    <BootstrapTableful
+    <BootstrapTable
       keyField="id"
       data={ products }
       columns={ columns }

--- a/packages/react-bootstrap-table2-example/examples/columns/column-hidden-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-hidden-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -28,12 +28,12 @@ const columns = [{
 // omit...
 ];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/column-style-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-style-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -58,12 +58,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/column-title-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/column-title-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -34,12 +34,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/columns/nested-data-table.js
+++ b/packages/react-bootstrap-table2-example/examples/columns/nested-data-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -49,12 +49,12 @@ const columns = [{
   text: 'PostCode'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/header-columns/column-align-table.js
+++ b/packages/react-bootstrap-table2-example/examples/header-columns/column-align-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -34,12 +34,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/header-columns/column-attrs-table.js
+++ b/packages/react-bootstrap-table2-example/examples/header-columns/column-attrs-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -34,12 +34,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/header-columns/column-class-table.js
+++ b/packages/react-bootstrap-table2-example/examples/header-columns/column-class-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -40,12 +40,12 @@ const columns = [{
   }
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/header-columns/column-event-table.js
+++ b/packages/react-bootstrap-table2-example/examples/header-columns/column-event-table.js
@@ -2,7 +2,7 @@
 /* eslint no-alert: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -37,13 +37,13 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
     <h3>Try to Click on Product ID header column</h3>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/header-columns/column-format-table.js
+++ b/packages/react-bootstrap-table2-example/examples/header-columns/column-format-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -40,7 +40,7 @@ const columns = [
   headerFormatter: priceFormatter
 }];
 
-<BootstrapTableful
+<BootstrapTable
   keyField="id"
   data={ products }
   columns={ columns }
@@ -49,7 +49,7 @@ const columns = [
 
 export default () => (
   <div>
-    <BootstrapTableful
+    <BootstrapTable
       keyField="id"
       data={ products }
       columns={ columns }

--- a/packages/react-bootstrap-table2-example/examples/header-columns/column-style-table.js
+++ b/packages/react-bootstrap-table2-example/examples/header-columns/column-style-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -56,12 +56,12 @@ const columns = [{
   }
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/header-columns/column-title-table.js
+++ b/packages/react-bootstrap-table2-example/examples/header-columns/column-title-table.js
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -34,12 +34,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/row-selection/multiple-selection.js
+++ b/packages/react-bootstrap-table2-example/examples/row-selection/multiple-selection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -37,7 +37,7 @@ const selectRowProp = {
   mode: 'checkbox'
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -47,7 +47,7 @@ const selectRowProp = {
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } selectRow={ selectRowProp } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } selectRow={ selectRowProp } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/row-selection/single-selection.js
+++ b/packages/react-bootstrap-table2-example/examples/row-selection/single-selection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -37,7 +37,7 @@ const selectRowProp = {
   mode: 'radio'
 };
 
-<BootstrapTableful
+<BootstrapTable
   keyField='id'
   data={ products }
   columns={ columns }
@@ -47,7 +47,7 @@ const selectRowProp = {
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } selectRow={ selectRowProp } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } selectRow={ selectRowProp } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/sort/custom-sort-table.js
+++ b/packages/react-bootstrap-table2-example/examples/sort/custom-sort-table.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -49,12 +49,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/examples/sort/enable-sort-table.js
+++ b/packages/react-bootstrap-table2-example/examples/sort/enable-sort-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { BootstrapTableful } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 import Code from 'components/common/code-block';
 import { productsGenerator } from 'utils/common';
 
@@ -33,12 +33,12 @@ const columns = [{
   text: 'Product Price'
 }];
 
-<BootstrapTableful keyField='id' data={ products } columns={ columns } />
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
 `;
 
 export default () => (
   <div>
-    <BootstrapTableful keyField="id" data={ products } columns={ columns } />
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
     <Code>{ sourceCode }</Code>
   </div>
 );

--- a/packages/react-bootstrap-table2-example/src/index.js
+++ b/packages/react-bootstrap-table2-example/src/index.js
@@ -4,7 +4,7 @@
 import React from 'react';
 import ReactDom from 'react-dom';
 
-import { BootstrapTableful, createTable } from 'react-bootstrap-table2';
+import BootstrapTable from 'react-bootstrap-table2';
 
 require('react-bootstrap-table2/style/react-bootstrap-table.scss');
 
@@ -114,5 +114,5 @@ const cellEdit = {
 // Table = createTable(Table);
 
 ReactDom.render(
-  <BootstrapTableful keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />,
+  <BootstrapTable keyField="id" data={ products } columns={ columns } cellEdit={ cellEdit } />,
   document.getElementById('example'));

--- a/packages/react-bootstrap-table2/src/container.js
+++ b/packages/react-bootstrap-table2/src/container.js
@@ -7,8 +7,8 @@ import Store from './store/base';
 import CellEditWrapper from './cell-edit/wrapper';
 import _ from './utils';
 
-const withStateful = (Base) => {
-  class StatefulComponent extends Component {
+const withDataStore = (Base) => {
+  return class BootstrapTableContainer extends Component {
     constructor(props) {
       super(props);
       this.store = new Store(props);
@@ -68,8 +68,7 @@ const withStateful = (Base) => {
       }
       return element;
     }
-  }
-  return StatefulComponent;
+  };
 };
 
-export default withStateful;
+export default withDataStore;

--- a/packages/react-bootstrap-table2/src/index.js
+++ b/packages/react-bootstrap-table2/src/index.js
@@ -1,9 +1,5 @@
 import BootstrapTable from './bootstrap-table';
 import withStateful from './stateful-layer';
 
-const BootstrapTableful = withStateful(BootstrapTable);
+export default withStateful(BootstrapTable);
 
-export {
-  BootstrapTable,
-  BootstrapTableful
-};

--- a/packages/react-bootstrap-table2/src/index.js
+++ b/packages/react-bootstrap-table2/src/index.js
@@ -1,5 +1,5 @@
 import BootstrapTable from './bootstrap-table';
-import withStateful from './stateful-layer';
+import withDataStore from './container';
 
-export default withStateful(BootstrapTable);
+export default withDataStore(BootstrapTable);
 

--- a/packages/react-bootstrap-table2/test/container.test.js
+++ b/packages/react-bootstrap-table2/test/container.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 
 import BootstrapTable from '../src';
 
-describe('withStateful', () => {
+describe('withDataStore', () => {
   let wrapper;
 
   const keyField = 'id';

--- a/packages/react-bootstrap-table2/test/stateful-layer.test.js
+++ b/packages/react-bootstrap-table2/test/stateful-layer.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import { BootstrapTable, BootstrapTableful } from '../src';
+import BootstrapTable from '../src';
 
 describe('withStateful', () => {
   let wrapper;
@@ -28,13 +28,12 @@ describe('withStateful', () => {
   describe('initialization', () => {
     beforeEach(() => {
       wrapper = shallow(
-        <BootstrapTableful keyField={ keyField } data={ data } columns={ columns } />
+        <BootstrapTable keyField={ keyField } data={ data } columns={ columns } />
       );
     });
 
     it('should render BootstrapTable successfully', () => {
       expect(wrapper.length).toBe(1);
-      expect(wrapper.find(BootstrapTable).length).toBe(1);
     });
 
     it('should creating store successfully', () => {
@@ -46,14 +45,14 @@ describe('withStateful', () => {
   });
 
   describe('when cellEdit is defined', () => {
-    const spy = jest.spyOn(BootstrapTableful.prototype, 'renderCellEdit');
+    const spy = jest.spyOn(BootstrapTable.prototype, 'renderCellEdit');
     const cellEdit = {
       mode: 'click'
     };
 
     beforeEach(() => {
       wrapper = shallow(
-        <BootstrapTableful
+        <BootstrapTable
           keyField={ keyField }
           data={ data }
           columns={ columns }
@@ -99,7 +98,7 @@ describe('withStateful', () => {
         beforeEach(() => {
           cellEdit.onUpdate = sinon.stub().returns(false);
           wrapper = shallow(
-            <BootstrapTableful
+            <BootstrapTable
               keyField={ keyField }
               data={ data }
               columns={ columns }


### PR DESCRIPTION
* change `stateful-layer.js` as `container.js`
* export default `BootstrapTable` which wrapped by `container.js`

Container component responsible for 
1. Creating store and inject to Base component
2. Render different Wrapper(like cell edit wrapper(`./cell-edit/wrapper.js`))

