### PR TITLE
logs messages on the story panel (#117)

### DIFF
--- a/packages/react-bootstrap-table2-example/.storybook/addons.js
+++ b/packages/react-bootstrap-table2-example/.storybook/addons.js
@@ -2,3 +2,4 @@
 
 import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
+import '@storybook/addon-console';

--- a/packages/react-bootstrap-table2-example/.storybook/config.js
+++ b/packages/react-bootstrap-table2-example/.storybook/config.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
 import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
+import { withConsole } from '@storybook/addon-console';
 
 function loadStories() {
   require('stories');
@@ -15,6 +16,10 @@ const componentDecorator = (story) => (
     { story() }
   </div>
 );
+
+
+// prepend the story name to log messages
+addDecorator((storyFn, context) => withConsole()(storyFn)(context));
 
 addDecorator(componentDecorator);
 

--- a/packages/react-bootstrap-table2-example/package.json
+++ b/packages/react-bootstrap-table2-example/package.json
@@ -20,6 +20,7 @@
     "react-bootstrap-table2": "0.0.1"
   },
   "devDependencies": {
+    "@storybook/addon-console": "^1.0.0",
     "@storybook/react": "^3.2.8",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",


### PR DESCRIPTION
#117 

This PR aims to print all console messages to `logger panel` with  [storybook-addon-console](https://github.com/storybooks/storybook-addon-console). Please refer to the pic below. So far it will print all the messages including `eslint` warning or something like that. If we wanna focus on the messages excluding system warning, we could add exclusive rule to ignore in the future.


<img width="1170" alt="2017-10-29 1 06 35" src="https://user-images.githubusercontent.com/7923460/32136761-425df46a-bbd9-11e7-99d1-0ad5a617f4a4.png">

