### PR TITLE
fix the typo of style path

### DIFF
--- a/packages/react-bootstrap-table2-example/.storybook/webpack.config.js
+++ b/packages/react-bootstrap-table2-example/.storybook/webpack.config.js
@@ -16,7 +16,6 @@ const aliasPath = {
   src: srcPath,
   components: path.join(srcPath, 'components'),
   utils: path.join(srcPath, 'utils'),
-
   'react-bootstrap-table-next': sourcePath,
   'react-bootstrap-table2-editor': editorSourcePath,
   'react-bootstrap-table2-filter': filterSourcePath,

--- a/packages/react-bootstrap-table2-example/stories/index.js
+++ b/packages/react-bootstrap-table2-example/stories/index.js
@@ -96,7 +96,7 @@ import RemoteAll from 'examples/remote/remote-all';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'stories/stylesheet/tomorrow.min.css';
 import 'stories/stylesheet/storybook.scss';
-import 'react-bootstrap-table2/style/react-bootstrap-table2.scss';
+import 'react-bootstrap-table-next/style/react-bootstrap-table2.scss';
 import 'react-bootstrap-table2-paginator/style/react-bootstrap-table2-paginator.scss';
 
 // import { action } from '@storybook/addon-actions';


### PR DESCRIPTION
Hi @AllenFang,

It's a tiny PR aims for typo fix. Besides, I was curious about the reason why to rename package to `react-bootstrap-table-next`. Is there naming conflict on `npm` or something like that?