### PR TITLE
Custom editor support

### DIFF
--- a/packages/react-bootstrap-table2-editor/index.js
+++ b/packages/react-bootstrap-table2-editor/index.js
@@ -5,6 +5,8 @@ import {
   DBCLICK_TO_CELL_EDIT,
   DELAY_FOR_DBCLICK
 } from './src/const';
+import TextEditor from './src/text-editor';
+import DropDownEditor from './src/dropdown-editor';
 
 export default (options = {}) => ({
   wrapperFactory,
@@ -14,3 +16,8 @@ export default (options = {}) => ({
   DELAY_FOR_DBCLICK,
   options
 });
+
+export {
+  TextEditor,
+  DropDownEditor
+};

--- a/packages/react-bootstrap-table2-editor/src/dropdown-editor.js
+++ b/packages/react-bootstrap-table2-editor/src/dropdown-editor.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cs from 'classnames';
+
+class DropDownEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onOptionSelected = this.onOptionSelected.bind(this);
+  }
+
+  onOptionSelected(e) {
+    if (this.props.updateValue != null) {
+      this.props.updateValue(e.target.value);
+    }
+    // simulate enter press so that value will be stored in handleKeyDown..
+    // nicer solution is to probably to handle events at editor component 
+    // and bubble the event up to a save event in editing cell
+    this.props.onKeyDown({ keyCode: 13 });
+  }
+
+  render() {
+    const options = [];
+    this.props.items.forEach((item, i) => {
+      const optionKey = this.props.dropDownKey + i;
+      const option = (
+        <option key={ optionKey } value={ item }>
+          { item }
+        </option>
+      );
+      options.push(option);
+    });
+
+    const editorClass = cs('form-control editor edit-dropdown', this.props.className);
+
+    return (
+      <select
+        defaultValue={ this.props.defaultValue }
+        className={ editorClass }
+        id={ `formcontrol-dropdown-${this.props.dropDownKey}` }
+        onChange={ this.onOptionSelected }
+      >
+        {options}
+      </select>
+    );
+  }
+}
+
+DropDownEditor.propTypes = {
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  defaultValue: PropTypes.string,
+  updateValue: PropTypes.func,
+  items: PropTypes.array,
+  dropDownKey: PropTypes.string,
+  onKeyDown: PropTypes.func
+};
+DropDownEditor.defaultProps = {
+  className: null,
+  defaultValue: '',
+  updateValue: () => {},
+  items: [],
+  dropDownKey: `key_${Math.random()}`,
+  onKeyDown: () => {}
+};
+export default DropDownEditor;

--- a/packages/react-bootstrap-table2-editor/src/dropdown-editor.js
+++ b/packages/react-bootstrap-table2-editor/src/dropdown-editor.js
@@ -59,7 +59,7 @@ DropDownEditor.propTypes = {
 DropDownEditor.defaultProps = {
   className: null,
   defaultValue: '',
-  updateValue: () => {},
+  updateValue: () => console.warn('update value needs to be implemented'),
   items: [],
   dropDownKey: `key_${Math.random()}`,
   onKeyDown: () => {}

--- a/packages/react-bootstrap-table2-editor/src/editing-cell.js
+++ b/packages/react-bootstrap-table2-editor/src/editing-cell.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react';
 import cs from 'classnames';
 import PropTypes from 'prop-types';
 
+import EditorWrapper from './editor-wrapper';
 import TextEditor from './text-editor';
 import EditorIndicator from './editor-indicator';
 import { TIME_TO_CLOSE_MESSAGE } from './const';
@@ -89,10 +90,7 @@ export default _ =>
     handleBlur() {
       const { onEscape, blurToSave, row, column } = this.props;
       if (blurToSave) {
-        const value = this.editor.text.value;
-        if (!_.isDefined(value)) {
-          // TODO: for other custom or embed editor
-        }
+        const { value } = this.editorWrapper;
         this.beforeComplete(row, column, value);
       } else {
         onEscape();
@@ -104,10 +102,7 @@ export default _ =>
       if (e.keyCode === 27) { // ESC
         onEscape();
       } else if (e.keyCode === 13) { // ENTER
-        const value = e.currentTarget.value;
-        if (!_.isDefined(value)) {
-          // TODO: for other custom or embed editor
-        }
+        const { value } = this.editorWrapper;
         this.beforeComplete(row, column, value);
       }
     }
@@ -125,6 +120,7 @@ export default _ =>
       const { invalidMessage } = this.state;
       const { row, column, className, style } = this.props;
       const { dataField } = column;
+      let { editor } = column;
 
       const value = _.get(row, dataField);
       const editorAttrs = {
@@ -134,16 +130,19 @@ export default _ =>
 
       const hasError = _.isDefined(invalidMessage);
       const editorClass = hasError ? cs('animated', 'shake') : null;
+      editor = editor || <TextEditor />;
+
       return (
         <td
           className={ cs('react-bootstrap-table-editing-cell', className) }
           style={ style }
           onClick={ this.handleClick }
         >
-          <TextEditor
-            ref={ node => this.editor = node }
+          <EditorWrapper
+            ref={ node => this.editorWrapper = node }
             defaultValue={ value }
             className={ editorClass }
+            editor={ editor }
             { ...editorAttrs }
           />
           { hasError ? <EditorIndicator invalidMessage={ invalidMessage } /> : null }

--- a/packages/react-bootstrap-table2-editor/src/editor-wrapper.js
+++ b/packages/react-bootstrap-table2-editor/src/editor-wrapper.js
@@ -1,0 +1,43 @@
+/* eslint no-return-assign: 0 */
+import React, { Component } from 'react';
+import cs from 'classnames';
+import PropTypes from 'prop-types';
+
+class EditorWrapper extends Component {
+  constructor(props) {
+    super(props);
+    this.value = props.defaultValue;
+  }  
+  
+  render() {
+    const { defaultValue, className, editor, ...rest } = this.props;    
+    const element = React.cloneElement(
+      editor, 
+      {
+        className: this.props.className,
+        defaultValue: this.props.defaultValue,
+        updateValue: (value) => this.value = value,
+        ...rest
+      }
+    );
+    return (
+      element
+    );
+  }
+}
+
+EditorWrapper.propTypes = {
+  className: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number
+  ]).isRequired,
+  editor: PropTypes.object.isRequired,
+};
+EditorWrapper.defaultProps = {
+  className: null
+};
+export default EditorWrapper;

--- a/packages/react-bootstrap-table2-editor/src/editor-wrapper.js
+++ b/packages/react-bootstrap-table2-editor/src/editor-wrapper.js
@@ -1,22 +1,21 @@
 /* eslint no-return-assign: 0 */
 import React, { Component } from 'react';
-import cs from 'classnames';
 import PropTypes from 'prop-types';
 
 class EditorWrapper extends Component {
   constructor(props) {
     super(props);
     this.value = props.defaultValue;
-  }  
-  
+  }
+
   render() {
-    const { defaultValue, className, editor, ...rest } = this.props;    
+    const { defaultValue, className, editor, ...rest } = this.props;
     const element = React.cloneElement(
       editor, 
       {
         className: this.props.className,
         defaultValue: this.props.defaultValue,
-        updateValue: (value) => this.value = value,
+        updateValue: value => this.value = value,
         ...rest
       }
     );
@@ -35,7 +34,7 @@ EditorWrapper.propTypes = {
     PropTypes.string,
     PropTypes.number
   ]).isRequired,
-  editor: PropTypes.object.isRequired,
+  editor: PropTypes.element.isRequired
 };
 EditorWrapper.defaultProps = {
   className: null

--- a/packages/react-bootstrap-table2-editor/src/text-editor.js
+++ b/packages/react-bootstrap-table2-editor/src/text-editor.js
@@ -40,6 +40,5 @@ TextEditor.defaultProps = {
   className: null,
   defaultValue: '',
   updateValue: () => console.warn('update value needs to be implemented')
-  ])
 };
 export default TextEditor;

--- a/packages/react-bootstrap-table2-editor/src/text-editor.js
+++ b/packages/react-bootstrap-table2-editor/src/text-editor.js
@@ -11,12 +11,13 @@ class TextEditor extends Component {
   }
 
   render() {
-    const { defaultValue, className, ...rest } = this.props;
+    const { defaultValue, className, updateValue, ...rest } = this.props;
     const editorClass = cs('form-control editor edit-text', className);
     return (
       <input
         ref={ node => this.text = node }
         type="text"
+        onChange={ e => this.props.updateValue(e.target.value) }
         className={ editorClass }
         { ...rest }
       />
@@ -32,9 +33,12 @@ TextEditor.propTypes = {
   defaultValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number
-  ]).isRequired
+  ]),
+  updateValue: PropTypes.func
 };
 TextEditor.defaultProps = {
-  className: null
+  className: null,
+  defaultValue: '',
+  updateValue: () => console.warn('update value needs to be implemented')
 };
 export default TextEditor;

--- a/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-custom-editors.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/cell-edit-custom-editors.js
@@ -1,0 +1,78 @@
+/* eslint no-unused-vars: 0 */
+/* eslint no-console: 0 */
+import React from 'react';
+
+import BootstrapTable from 'react-bootstrap-table-next';
+import cellEditFactory, { DropDownEditor } from 'react-bootstrap-table2-editor';
+import Code from 'components/common/code-block';
+import { productsGenerator } from 'utils/common';
+
+const products = productsGenerator();
+
+const items = [
+  'Item name 0',
+  'Item name 1',
+  'Item name 2',
+  'Item name 3',
+  'Item name 4'
+];
+const columns = [{
+  dataField: 'id',
+  text: 'Product ID'
+}, {
+  dataField: 'name',
+  text: 'Product Name',
+  editor: (<DropDownEditor dropDownKey="productName" items={ items } />)
+}, {
+  dataField: 'price',
+  text: 'Product Price'
+}];
+
+const sourceCode = `\
+import BootstrapTable from 'react-bootstrap-table-next';
+import cellEditFactory, { DropDownEditor } from 'react-bootstrap-table2-editor';
+
+const items = [
+  'Item name 0',
+  'Item name 1',
+  'Item name 2',
+  'Item name 3',
+  'Item name 4'
+];
+const columns = [{
+  dataField: 'id',
+  text: 'Product ID'
+}, {
+  dataField: 'name',
+  text: 'Product Name',
+  editor: (<DropDownEditor dropDownKey="productName" items={ items } />)
+}, {
+  dataField: 'price',
+  text: 'Product Price'
+}];
+
+<BootstrapTable
+  keyField="id"
+  data={ products }
+  columns={ columns }
+  cellEdit={ cellEditFactory({
+    mode: 'click',
+    afterSaveCell: (oldValue, newValue, row, column) => { console.log(\`Dropdown select from '\${oldValue}' to '\${newValue}'\`); }
+  }) }
+/>
+`;
+
+export default () => (
+  <div>
+    <BootstrapTable
+      keyField="id"
+      data={ products }
+      columns={ columns }
+      cellEdit={ cellEditFactory({
+        mode: 'click',
+        afterSaveCell: (oldValue, newValue, row, column) => { console.log(`Dropdown select from '${oldValue}' to '${newValue}'`); }
+      }) }
+    />
+    <Code>{ sourceCode }</Code>
+  </div>
+);

--- a/packages/react-bootstrap-table2-example/stories/index.js
+++ b/packages/react-bootstrap-table2-example/stories/index.js
@@ -64,6 +64,7 @@ import RowLevelEditableTable from 'examples/cell-edit/row-level-editable-table';
 import ColumnLevelEditableTable from 'examples/cell-edit/column-level-editable-table';
 import CellLevelEditable from 'examples/cell-edit/cell-level-editable-table';
 import CellEditHooks from 'examples/cell-edit/cell-edit-hooks-table';
+import CellCustomEditors from 'examples/cell-edit/cell-edit-custom-editors';
 import CellEditValidator from 'examples/cell-edit/cell-edit-validator-table';
 import CellEditStyleTable from 'examples/cell-edit/cell-edit-style-table';
 import CellEditClassTable from 'examples/cell-edit/cell-edit-class-table';
@@ -173,7 +174,9 @@ storiesOf('Cell Editing', module)
   .add('Rich Hook Functions', () => <CellEditHooks />)
   .add('Validation', () => <CellEditValidator />)
   .add('Custom Cell Style When Editing', () => <CellEditStyleTable />)
-  .add('Custom Cell Classes When Editing', () => <CellEditClassTable />);
+  .add('Custom Cell Classes When Editing', () => <CellEditClassTable />)
+  .add('Custom Editors for editing', () => <CellCustomEditors />);
+
 
 storiesOf('Row Selection', module)
   .add('Single Selection', () => <SingleSelectionTable />)


### PR DESCRIPTION
Hi,

Thanks for the great library. I needed to have support for editing with drop down, which I have implemented as per this pull request. This implementation allows any custom component to be embedded as editor. 

How it works:
- import or create own custom editor. I've added dropdown editor to the package. TextEditor and DropDownEditor can be imported like: `import cellEditFactory, { DropDownEditor } from 'react-bootstrap-table2-editor';`
- define column like this:
`const columns = [{
  dataField: 'name',
  text: 'Product Name',
  editor: (<DropDownEditor dropDownKey="productName" items={ ['A', 'B', 'C'] } />)
}];`
- enable cell editing as you normally would: `<BootstrapTable
  keyField="id"
  data={ products }
  columns={ columns }
  cellEdit={ cellEditFactory({
    mode: 'click',
    afterSaveCell: (oldValue, newValue, row, column) => { console.log(\`Value changed from '\${oldValue}' to '\${newValue}'\`); }
  }) }
/>`

Main Changes:
- Added an EditorWrapper. This wrapper clones the editor element and adds properties. The purpose of this wrapper is to standardize the way how the editing cell can access the value from the editor component. That is, it adds the updateValue callback as property to the editor component. The editor component needs to call this callback to update the value.
- Added DropDownEditor. This is a component very similar to TextEditor, except it uses a dropdown to select values from a list.
- Modified EditingCell to use EditorWrapper instead of directly using TextEditor. It also passes on the editor property to the wrapper. By default the TextEditor is used.

I've also added a Storyboard example to illustrate usage (see last item under cell edit).

Note: open item is where have events  like onblur, onkeydown handled. I've left it as it is currently implemented (Editing Cell has handleBlur, handleKeyDown defined). However, it might be better to have the editor component handle the events. As these events differ among HTML elements (e.g., select has no onblur event). My proposal would be to manage events at the editor component level and have a callback in EditingCell for managing value changes.