### PR TITLE
noDataIndication

### DIFF
--- a/packages/react-bootstrap-table2-example/examples/row-selection/selection-no-data.js
+++ b/packages/react-bootstrap-table2-example/examples/row-selection/selection-no-data.js
@@ -1,0 +1,62 @@
+/* eslint no-unused-vars: 0 */
+import React from 'react';
+
+import BootstrapTable from 'react-bootstrap-table-next';
+import Code from 'components/common/code-block';
+
+const columns = [{
+  dataField: 'id',
+  text: 'Product ID'
+}, {
+  dataField: 'name',
+  text: 'Product Name'
+}, {
+  dataField: 'price',
+  text: 'Product Price'
+}];
+
+const selectRow1 = {
+  mode: 'checkbox',
+  clickToSelect: true
+};
+
+const sourceCode1 = `\
+import BootstrapTable from 'react-bootstrap-table-next';
+
+const columns = [{
+  dataField: 'id',
+  text: 'Product ID'
+}, {
+  dataField: 'name',
+  text: 'Product Name'
+}, {
+  dataField: 'price',
+  text: 'Product Price'
+}];
+
+const selectRow = {
+  mode: 'checkbox',
+  clickToSelect: true
+};
+
+<BootstrapTable
+  keyField='id'
+  data={ [] }
+  columns={ columns }
+  selectRow={ selectRow }
+  noDataIndication={ 'no results found' }
+/>
+`;
+
+export default () => (
+  <div>
+    <BootstrapTable
+      keyField="id"
+      data={ [] }
+      columns={ columns }
+      selectRow={ selectRow1 }
+      noDataIndication={ 'no results found' }
+    />
+    <Code>{ sourceCode1 }</Code>
+  </div>
+);

--- a/packages/react-bootstrap-table2-example/stories/index.js
+++ b/packages/react-bootstrap-table2-example/stories/index.js
@@ -81,6 +81,7 @@ import ClickToSelectTable from 'examples/row-selection/click-to-select';
 import DefaultSelectTable from 'examples/row-selection/default-select';
 import SelectionManagement from 'examples/row-selection/selection-management';
 import ClickToSelectWithCellEditTable from 'examples/row-selection/click-to-select-with-cell-edit';
+import SelectionNoDataTable from 'examples/row-selection/selection-no-data';
 import SelectionStyleTable from 'examples/row-selection/selection-style';
 import SelectionClassTable from 'examples/row-selection/selection-class';
 import NonSelectableRowsTable from 'examples/row-selection/non-selectable-rows';
@@ -196,6 +197,7 @@ storiesOf('Row Selection', module)
   .add('Default Select', () => <DefaultSelectTable />)
   .add('Selection Management', () => <SelectionManagement />)
   .add('Click to Select and Edit Cell', () => <ClickToSelectWithCellEditTable />)
+  .add('Selection without Data', () => <SelectionNoDataTable />)
   .add('Selection Style', () => <SelectionStyleTable />)
   .add('Selection Class', () => <SelectionClassTable />)
   .add('Selection Background Color', () => <SelectionBgColorTable />)

--- a/packages/react-bootstrap-table2/src/props-resolver/column-resolver.js
+++ b/packages/react-bootstrap-table2/src/props-resolver/column-resolver.js
@@ -1,6 +1,11 @@
 export default ExtendBase =>
   class ColumnResolver extends ExtendBase {
-    visibleColumnSize() {
-      return this.props.columns.filter(c => !c.hidden).length;
+    visibleColumnSize(includeSelectColumn = true) {
+      let columnLen = this.props.columns.filter(c => !c.hidden).length;
+      if (!includeSelectColumn) return columnLen;
+      if (this.props.selectRow && !this.props.selectRow.hideSelectColumn) {
+        columnLen + 1;
+      }
+      return columnLen;
     }
   };

--- a/packages/react-bootstrap-table2/src/props-resolver/column-resolver.js
+++ b/packages/react-bootstrap-table2/src/props-resolver/column-resolver.js
@@ -1,10 +1,10 @@
 export default ExtendBase =>
   class ColumnResolver extends ExtendBase {
     visibleColumnSize(includeSelectColumn = true) {
-      let columnLen = this.props.columns.filter(c => !c.hidden).length;
+      const columnLen = this.props.columns.filter(c => !c.hidden).length;
       if (!includeSelectColumn) return columnLen;
       if (this.props.selectRow && !this.props.selectRow.hideSelectColumn) {
-        columnLen + 1;
+        return columnLen + 1;
       }
       return columnLen;
     }

--- a/packages/react-bootstrap-table2/src/props-resolver/index.js
+++ b/packages/react-bootstrap-table2/src/props-resolver/index.js
@@ -5,12 +5,12 @@ import _ from '../utils';
 export default ExtendBase =>
   class TableResolver extends ColumnResolver(ExtendBase) {
     validateProps() {
-      const { columns, keyField } = this.props;
+      const { keyField } = this.props;
       if (!keyField) {
         throw new Error('Please specify a field as key via keyField');
       }
-      if (this.visibleColumnSize(columns) <= 0) {
-        throw new Error('No any visible columns detect');
+      if (this.visibleColumnSize(false) <= 0) {
+        throw new Error('No visible columns detected');
       }
     }
 

--- a/packages/react-bootstrap-table2/test/props-resolver/index.test.js
+++ b/packages/react-bootstrap-table2/test/props-resolver/index.test.js
@@ -56,7 +56,7 @@ describe('TableResolver', () => {
       });
     });
 
-    describe('if columns is all unvisible', () => {
+    describe('if no columns are visible', () => {
       beforeEach(() => {
         const mockElement = React.createElement(BootstrapTableMock, {
           data, keyField, columns: []
@@ -67,7 +67,7 @@ describe('TableResolver', () => {
       it('should throw error', () => {
         expect(() =>
           wrapper.instance().validateProps()
-        ).toThrow(new Error('No any visible columns detect'));
+        ).toThrow(new Error('No visible columns detected'));
       });
     });
   });


### PR DESCRIPTION
* use the correct amount of cells when the first row is select
* storybook added for development, not necessary in docs

fixes react-bootstrap-table/react-bootstrap-table2#264