### PR TITLE
Fix textFilter() for Internet Explorer (includes() and find() are not supported) 

### DIFF
--- a/packages/react-bootstrap-table2-filter/src/filter.js
+++ b/packages/react-bootstrap-table2-filter/src/filter.js
@@ -107,10 +107,9 @@ export const filters = (store, columns, _) => (currFilters) => {
     const filterObj = currFilters[dataField];
     filterFn = factory(filterObj.filterType);
     let filterValue;
-    const keys = Object.keys(columns);
-    for (let i = 0; i < keys.length; i += 1) {
-      if (columns[keys[i]].dataField === dataField) {
-        filterValue = columns[keys[i]].filterValue;
+    for (let i = 0; i < columns.length; i += 1) {
+      if (columns[i].dataField === dataField) {
+        filterValue = columns[i].filterValue;
         break;
       }
     }

--- a/packages/react-bootstrap-table2-filter/src/filter.js
+++ b/packages/react-bootstrap-table2-filter/src/filter.js
@@ -21,7 +21,7 @@ export const filterByText = _ => (
     if (caseSensitive) {
       return cellStr.includes(filterVal);
     }
-    return cellStr.toLocaleUpperCase().includes(filterVal.toLocaleUpperCase());
+    return cellStr.toLocaleUpperCase().indexOf(filterVal.toLocaleUpperCase()) !== -1;
   });
 
 export const filterByNumber = _ => (
@@ -106,7 +106,14 @@ export const filters = (store, columns, _) => (currFilters) => {
   Object.keys(currFilters).forEach((dataField) => {
     const filterObj = currFilters[dataField];
     filterFn = factory(filterObj.filterType);
-    const { filterValue } = columns.find(col => col.dataField === dataField);
+    let filterValue;
+    const keys = Object.keys(columns);
+    for (let i = 0; i < keys.length; i += 1) {
+      if (columns[keys[i]].dataField === dataField) {
+        filterValue = columns[keys[i]].filterValue;
+        break;
+      }
+    }
     result = filterFn(result, dataField, filterObj, filterValue);
   });
   return result;

--- a/packages/react-bootstrap-table2/src/sort/wrapper.js
+++ b/packages/react-bootstrap-table2/src/sort/wrapper.js
@@ -39,8 +39,14 @@ export default Base =>
     }
 
     componentWillReceiveProps(nextProps) {
-      const sortedColumn = nextProps.columns.find(
-        column => column.dataField === nextProps.store.sortField);
+      let sortedColumn;
+      const keys = Object.keys(nextProps.columns);
+      for (let i = 0; i < keys.length; i += 1) {
+        if (nextProps.columns[keys[i]].dataField === nextProps.store.sortField) {
+          sortedColumn = nextProps.columns[keys[i]];
+          break;
+        }
+      }
       if (sortedColumn && sortedColumn.sort) {
         nextProps.store.sortBy(sortedColumn);
       }

--- a/packages/react-bootstrap-table2/src/sort/wrapper.js
+++ b/packages/react-bootstrap-table2/src/sort/wrapper.js
@@ -40,10 +40,9 @@ export default Base =>
 
     componentWillReceiveProps(nextProps) {
       let sortedColumn;
-      const keys = Object.keys(nextProps.columns);
-      for (let i = 0; i < keys.length; i += 1) {
-        if (nextProps.columns[keys[i]].dataField === nextProps.store.sortField) {
-          sortedColumn = nextProps.columns[keys[i]];
+      for (let i = 0; i < nextProps.columns.length; i += 1) {
+        if (nextProps.columns[i].dataField === nextProps.store.sortField) {
+          sortedColumn = nextProps.columns[i];
           break;
         }
       }


### PR DESCRIPTION
Fix textFilter() for Internet Explorer (includes() and find() are not supported) 
- replace includes() with indexOf() !== -1
  - [includes() browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Browser_compatibility)
- replace find() with for loop
  - [find() browser compatibility](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find#Browser_compatibility)