### PR TITLE
Ability to add classes to the table wrapper

### DIFF
--- a/packages/react-bootstrap-table2/src/bootstrap-table.js
+++ b/packages/react-bootstrap-table2/src/bootstrap-table.js
@@ -52,8 +52,11 @@ class BootstrapTable extends PropsBaseResolver(Component) {
       caption,
       rowStyle,
       rowClasses,
+      wrapperClasses,
       rowEvents
     } = this.props;
+
+    const tableWrapperClass = cs('react-bootstrap-table', wrapperClasses);
 
     const tableClass = cs('table', {
       'table-striped': striped,
@@ -75,7 +78,7 @@ class BootstrapTable extends PropsBaseResolver(Component) {
     const tableCaption = (caption && <Caption>{ caption }</Caption>);
 
     return (
-      <div className="react-bootstrap-table">
+      <div className={ tableWrapperClass }>
         <table id={ id } className={ tableClass }>
           { tableCaption }
           <Header
@@ -120,6 +123,7 @@ BootstrapTable.propTypes = {
   hover: PropTypes.bool,
   id: PropTypes.string,
   classes: PropTypes.string,
+  wrapperClasses: PropTypes.string,
   condensed: PropTypes.bool,
   caption: PropTypes.oneOfType([
     PropTypes.node,


### PR DESCRIPTION
Let's say I need to add a 'table-responsive' class or another custom class.

The https://github.com/react-bootstrap-table/react-bootstrap-table2/pull/317 can be closed 