### PR TITLE
Prevent remote pagination from setting the page incorrectly

### DIFF
--- a/packages/react-bootstrap-table2-paginator/src/wrapper.js
+++ b/packages/react-bootstrap-table2-paginator/src/wrapper.js
@@ -54,9 +54,12 @@ export default (Base, {
       if (typeof page !== 'undefined' && currPage !== page) { // user defined page
         currPage = page;
         needNewState = true;
-      } else if (nextProps.isDataChanged) { // user didn't defined page but data change
-        currPage = typeof pageStartIndex !== 'undefined' ? pageStartIndex : Const.PAGE_START_INDEX;
+      } else if (nextProps.isDataChanged) {
         needNewState = true;
+      }
+
+      if (typeof currPage === 'undefined') {
+        currPage = typeof pageStartIndex !== 'undefined' ? pageStartIndex : Const.PAGE_START_INDEX;
       }
 
       if (typeof sizePerPage !== 'undefined') {

--- a/packages/react-bootstrap-table2-paginator/test/wrapper.test.js
+++ b/packages/react-bootstrap-table2-paginator/test/wrapper.test.js
@@ -177,10 +177,11 @@ describe('Wrapper', () => {
         });
       });
 
-      describe('when nextProps.isDataChanged is true and options.pageStartIndex is existing', () => {
+      describe('when nextProps.isDataChanged is true, currPage is undefined and options.pageStartIndex exists', () => {
         beforeEach(() => {
           nextProps.isDataChanged = true;
           nextProps.pagination.options.pageStartIndex = 0;
+          instance.state.currPage = undefined;
           instance.componentWillReceiveProps(nextProps);
         });
 


### PR DESCRIPTION
The issue:
When changing pages on a remote implementation with filters componentWillReceiveProps fires twice. It fires once on the initial page change click, and again when the updated data is received. Therefore, when data (2nd time it fires) is received the current logic believes a page hasn't been selected. It subsequently sets the current page to the start index value incorrectly.
For example, with my remote implementation: if I select page 4, the second time pagination componentWillReceiveProps fires, I end up with page 1 being selected whilst I have received page 4 data.