### PR TITLE
[WIP] Row as a pure component

### DIFF
--- a/packages/react-bootstrap-table2-example/package.json
+++ b/packages/react-bootstrap-table2-example/package.json
@@ -14,8 +14,8 @@
   "license": "ISC",
   "peerDependencies": {
     "prop-types": "^15.0.0",
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "bootstrap": "^3.3.7"

--- a/packages/react-bootstrap-table2/src/body.js
+++ b/packages/react-bootstrap-table2/src/body.js
@@ -10,6 +10,12 @@ import Row from './row';
 import RowSection from './row-section';
 import Const from './const';
 
+const empty = {
+  cellEdit: [],
+  attrs: {},
+  style: {}
+};
+
 const Body = (props) => {
   const {
     columns,
@@ -40,7 +46,7 @@ const Body = (props) => {
     }
     content = <RowSection content={ indication } colSpan={ visibleColumnSize } />;
   } else {
-    const nonEditableRows = cellEdit.nonEditableRows || [];
+    const nonEditableRows = cellEdit.nonEditableRows || empty.cellEdit;
     content = data.map((row, index) => {
       const key = _.get(row, keyField);
       const editable = !(nonEditableRows.length > 0 && nonEditableRows.indexOf(key) > -1);
@@ -49,7 +55,7 @@ const Body = (props) => {
         ? selectedRowKeys.includes(key)
         : null;
 
-      const attrs = rowEvents || {};
+      const attrs = rowEvents || empty.attrs;
       let style = _.isFunction(rowStyle) ? rowStyle(row, index) : rowStyle;
       let classes = (_.isFunction(rowClasses) ? rowClasses(row, index) : rowClasses);
       if (selected) {
@@ -68,7 +74,7 @@ const Body = (props) => {
         classes = cs(classes, selectedClasses);
 
         if (bgColor) {
-          style = style || {};
+          style = style || empty.style;
           style.backgroundColor = _.isFunction(bgColor) ? bgColor(row, index) : bgColor;
         }
       }

--- a/packages/react-bootstrap-table2/src/bootstrap-table.js
+++ b/packages/react-bootstrap-table2/src/bootstrap-table.js
@@ -12,18 +12,46 @@ import Const from './const';
 import { isSelectedAll } from './store/selection';
 
 class BootstrapTable extends PropsBaseResolver(Component) {
+  empty = {
+    cellEdit: {}
+  };
+
   constructor(props) {
     super(props);
     this.validateProps();
 
+    const cellSelectionInfo = this.getCellSelectionInfo(null, {}, props);
+
     this.state = {
-      data: props.data
+      data: props.data,
+      cellSelectionInfo
     };
   }
 
+  getCellSelectionInfo(old, props, nextProps) {
+    let cellSelectionInfo = old;
+    if (props.selectRow !== nextProps.selectRow
+      || props.onRowSelect !== nextProps.onRowSelect
+      || old === null
+    ) {
+      cellSelectionInfo = this.constructor.resolveSelectRowProps(nextProps.selectRow, {
+        onRowSelect: nextProps.onRowSelect
+      });
+    }
+
+    return cellSelectionInfo;
+  }
+
   componentWillReceiveProps(nextProps) {
+    const cellSelectionInfo = this.getCellSelectionInfo(
+      this.state.cellSelectionInfo,
+      this.props,
+      nextProps
+    );
+
     this.setState({
-      data: nextProps.data
+      data: nextProps.data,
+      cellSelectionInfo
     });
   }
 
@@ -68,10 +96,6 @@ class BootstrapTable extends PropsBaseResolver(Component) {
       'table-condensed': condensed
     }, classes);
 
-    const cellSelectionInfo = this.resolveSelectRowProps({
-      onRowSelect: this.props.onRowSelect
-    });
-
     const headerCellSelectionInfo = this.resolveSelectRowPropsForHeader({
       onAllRowsSelect: this.props.onAllRowsSelect,
       selected: store.selected,
@@ -100,8 +124,8 @@ class BootstrapTable extends PropsBaseResolver(Component) {
             isEmpty={ this.isEmpty() }
             visibleColumnSize={ this.visibleColumnSize() }
             noDataIndication={ noDataIndication }
-            cellEdit={ this.props.cellEdit || {} }
-            selectRow={ cellSelectionInfo }
+            cellEdit={ this.props.cellEdit || this.empty.cellEdit }
+            selectRow={ this.state.cellSelectionInfo }
             selectedRowKeys={ store.selected }
             rowStyle={ rowStyle }
             rowClasses={ rowClasses }

--- a/packages/react-bootstrap-table2/src/props-resolver/index.js
+++ b/packages/react-bootstrap-table2/src/props-resolver/index.js
@@ -20,13 +20,13 @@ export default ExtendBase =>
 
     /**
      * props resolver for cell selection
+     * @param {Object} selectRow
      * @param {Object} options - addtional options like callback which are about to merge into props
      *
      * @returns {Object} result - props for cell selections
      * @returns {String} result.mode - input type of row selection or disabled.
      */
-    resolveSelectRowProps(options) {
-      const { selectRow } = this.props;
+    static resolveSelectRowProps(selectRow, options) {
       const { ROW_SELECT_DISABLED } = Const;
 
       if (_.isDefined(selectRow)) {

--- a/packages/react-bootstrap-table2/src/row.js
+++ b/packages/react-bootstrap-table2/src/row.js
@@ -1,6 +1,6 @@
 /* eslint react/prop-types: 0 */
 /* eslint react/no-array-index-key: 0 */
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import _ from './utils';
@@ -9,7 +9,7 @@ import SelectionCell from './row-selection/selection-cell';
 import eventDelegater from './row-event-delegater';
 import Const from './const';
 
-class Row extends eventDelegater(Component) {
+class Row extends eventDelegater(PureComponent) {
   render() {
     const {
       row,

--- a/packages/react-bootstrap-table2/test/props-resolver/index.test.js
+++ b/packages/react-bootstrap-table2/test/props-resolver/index.test.js
@@ -82,7 +82,8 @@ describe('TableResolver', () => {
           data, keyField, columns
         }, null);
         wrapper = shallow(mockElement);
-        cellSelectionInfo = wrapper.instance().resolveSelectRowProps();
+        const instance = wrapper.instance();
+        cellSelectionInfo = instance.constructor.resolveSelectRowProps(instance.props.selectRow);
       });
 
       it('should return object', () => {
@@ -103,7 +104,8 @@ describe('TableResolver', () => {
             data, keyField, columns, selectRow
           }, null);
           wrapper = shallow(mockElement);
-          cellSelectionInfo = wrapper.instance().resolveSelectRowProps();
+          const instance = wrapper.instance();
+          cellSelectionInfo = instance.constructor.resolveSelectRowProps(instance.props.selectRow);
 
           expect(cellSelectionInfo).toBeDefined();
           expect(cellSelectionInfo.constructor).toEqual(Object);
@@ -116,7 +118,8 @@ describe('TableResolver', () => {
             data, keyField, columns, selectRow
           }, null);
           wrapper = shallow(mockElement);
-          cellSelectionInfo = wrapper.instance().resolveSelectRowProps();
+          const instance = wrapper.instance();
+          cellSelectionInfo = instance.constructor.resolveSelectRowProps(instance.props.selectRow);
 
           expect(cellSelectionInfo).toBeDefined();
           expect(cellSelectionInfo.constructor).toEqual(Object);
@@ -135,7 +138,11 @@ describe('TableResolver', () => {
             data, keyField, columns, selectRow
           }, null);
           wrapper = shallow(mockElement);
-          cellSelectionInfo = wrapper.instance().resolveSelectRowProps(mockOptions);
+          const instance = wrapper.instance();
+          cellSelectionInfo = instance.constructor.resolveSelectRowProps(
+            instance.props.selectRow,
+            mockOptions
+          );
         });
 
         it('should return object which contain options', () => {


### PR DESCRIPTION
So this is a first attempt to make this table library more performant.
This PR covers only the `Row` component (in `Body`), because it is the most important and it covers only some cases. It handles `rowClasses` and `rowEvents` well (at least in our case), which is our use-case.

Current issues of this PR:
1. It doesn't handle `selectRow` well when it has `selected` that changes. We probably need deep comparison there. Also, if someone changes `selectRow.selected`, it gets passed to every row, so that would need rework as well. Since this little thing is quite complex, it would probably be better to resolve this in another PR.
2. Not sure if creating the `empty` placeholders for all things is a good pattern. We could also do `emptyPlainObject = {};` and `emptyArray = [];` and share that globally. Do we care?
3. I've made an ugly thing with the `cellSelectionInfo`. Not sure if merg-eable like this.
4. I had to make `resolveSelectRowProps` static for the purpose above. Also not sure if it makes sense mixed like this with the other methods.
5. Putting stuff into `componentWillReceiveProps` is probably not a good idea, because it is deprecated and will be removed in React 17. I couldn't figure out another easy approach though. `getDerivedStateFromProps` is static unfortunately.
6. Probably other stuff due to my inexperience with this library.

This is mainly to kick-off the discussion about this. I think it would be awesome, if even a basic version of this concept would be merged, since preventing some parts of the table to re-render needlessly is a much more difficult task and every small step is a benefit (especially doing this for the `Row` component).

I appreciate ideas / comments / ...

Thank you.