### PR TITLE
Resolved issues with Date Filter to make its behavior the same as Number Filter

### DIFF
--- a/packages/react-bootstrap-table2-filter/src/components/date.js
+++ b/packages/react-bootstrap-table2-filter/src/components/date.js
@@ -93,12 +93,16 @@ class DateFilter extends Component {
   }
 
   applyFilter(value, comparator) {
-    if (!comparator || !value) {
-      return;
-    }
+    // if (!comparator || !value) {
+    //  return;
+    // }
     const { column, onFilter, delay } = this.props;
     const execute = () => {
-      const date = typeof value !== 'object' ? new Date(value) : value;
+      // Incoming value should always be a string, and the defaultDate
+      // above is implemented as an empty string, so we can just check for that.
+      // instead of parsing an invalid Date. The filter function will interpret
+      // null as an empty date field
+      const date = value === '' ? null : new Date(value);
       onFilter(column, FILTER_TYPE.DATE)({ date, comparator });
     };
     if (delay) {


### PR DESCRIPTION
Fix for my issue  #423 

Commented out a check which caused the date filter to not update the table when the date or date comparator were cleared

Modified applyFilter in date.js so that it doesn't try to parse an
Invalid Date. It was parsing an empty string, which caused it to pass
through an invalid date to onFilter, and this wasn't being checked for
properly by the onFilter function. It now checks for the empty string
and passes in null, which is what the onFilter function was actually
checking for