### PR TITLE
fix double triggered onTableChange on dateFilters

### DIFF
--- a/packages/react-bootstrap-table2-filter/src/components/date.js
+++ b/packages/react-bootstrap-table2-filter/src/components/date.js
@@ -93,9 +93,9 @@ class DateFilter extends Component {
   }
 
   applyFilter(value, comparator, isInitial) {
-    // if (!comparator || !value) {
-    //  return;
-    // }
+    if ((!comparator && value) || (!value && comparator)) {
+      return;
+    }
     const { column, onFilter, delay } = this.props;
     const execute = () => {
       // Incoming value should always be a string, and the defaultDate


### PR DESCRIPTION
With remote filters "on" onTableChange was triggered after every change in the date filter.
So it is was possible to get the date filter without a comparator, or without a date.

With this change onTableChange is only triggered, if both (comparator and date) are set, or both are not set (to reset the filter).