### PR TITLE
suspected bug in page.js

### DIFF
--- a/packages/react-bootstrap-table2-paginator/src/page.js
+++ b/packages/react-bootstrap-table2-paginator/src/page.js
@@ -23,10 +23,9 @@ export const alignPage = (
   sizePerPage,
   pageStartIndex
 ) => {
-  const end = endIndex(page, sizePerPage, pageStartIndex);
   const dataSize = data.length;
 
-  if (end - 1 > dataSize) {
+  if (page < pageStartIndex || page > Math.ceil(dataSize / sizePerPage)) {
     return pageStartIndex;
   }
   return page;


### PR DESCRIPTION
Local pagination aligning returns start page when eg editing cell locally. This results in state change, too. Not really getting the purpose of the original idea. Please consider this modification. It only checks if page fits in the data size range. As I saw, this alignment only affects local pagination, not remote.