### PR TITLE
Copas2 patch pagination

### DIFF
--- a/packages/react-bootstrap-table2-paginator/src/page.js
+++ b/packages/react-bootstrap-table2-paginator/src/page.js
@@ -25,7 +25,7 @@ export const alignPage = (
 ) => {
   const dataSize = data.length;
 
-  if (page < pageStartIndex || page > Math.ceil(dataSize / sizePerPage)) {
+  if (page < pageStartIndex || page > (Math.floor(dataSize / sizePerPage) + pageStartIndex)) {
     return pageStartIndex;
   }
   return page;

--- a/packages/react-bootstrap-table2-paginator/src/page.js
+++ b/packages/react-bootstrap-table2-paginator/src/page.js
@@ -23,10 +23,9 @@ export const alignPage = (
   sizePerPage,
   pageStartIndex
 ) => {
-  const end = endIndex(page, sizePerPage, pageStartIndex);
   const dataSize = data.length;
 
-  if (end - 1 > dataSize) {
+  if (page < pageStartIndex || page > Math.ceil(dataSize / sizePerPage)) {
     return pageStartIndex;
   }
   return page;

--- a/packages/react-bootstrap-table2-paginator/test/page.test.js
+++ b/packages/react-bootstrap-table2-paginator/test/page.test.js
@@ -45,8 +45,8 @@ describe('Page Functions', () => {
   describe('alignPage', () => {
     const pageStartIndex = 1;
     const sizePerPage = 10;
-    const page = 2;
-    describe('if the length of store.data is less than the end page index', () => {
+    const page = 3;
+    describe('if the page does not fit the pages interval calculated from the length of store.data', () => {
       beforeEach(() => {
         data = [];
         for (let i = 0; i < 15; i += 1) {


### PR DESCRIPTION
Local pagination aligning returns start page when eg editing cell locally. This results in state change, too. Not really getting the purpose of the original idea. Please consider this modification. It only checks if page fits in the data size range. As I saw, this alignment only affects local pagination, not remote.