### PR TITLE
fix clickToSelect=false being ignored when expandRow is active, also added table-responsive support.

### DIFF
--- a/packages/react-bootstrap-table2/src/bootstrap-table.js
+++ b/packages/react-bootstrap-table2/src/bootstrap-table.js
@@ -50,6 +50,7 @@ class BootstrapTable extends PropsBaseResolver(Component) {
       hover,
       bordered,
       condensed,
+      responsive,
       noDataIndication,
       caption,
       rowStyle,
@@ -65,7 +66,8 @@ class BootstrapTable extends PropsBaseResolver(Component) {
       'table-striped': striped,
       'table-hover': hover,
       'table-bordered': bordered,
-      'table-condensed': condensed
+      'table-condensed': condensed,
+      'table-responsive': responsive
     }, classes);
 
     const cellSelectionInfo = this.resolveSelectRowProps({
@@ -135,6 +137,7 @@ BootstrapTable.propTypes = {
   classes: PropTypes.string,
   wrapperClasses: PropTypes.string,
   condensed: PropTypes.bool,
+  responsive: PropTypes.bool,
   caption: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.string
@@ -200,6 +203,7 @@ BootstrapTable.defaultProps = {
   bordered: true,
   hover: false,
   condensed: false,
+  responsive: false,
   noDataIndication: null
 };
 

--- a/packages/react-bootstrap-table2/src/row-event-delegater.js
+++ b/packages/react-bootstrap-table2/src/row-event-delegater.js
@@ -73,7 +73,7 @@ export default ExtendBase =>
     delegate(attrs = {}) {
       const newAttrs = {};
       const { expandRow, selectRow } = this.props;
-      if (expandRow || (selectRow && selectRow.clickToSelect)) {
+      if (expandRow && (selectRow && selectRow.clickToSelect)) {
         newAttrs.onClick = this.createClickEventHandler(attrs.onClick);
       }
       Object.keys(attrs).forEach((attr) => {


### PR DESCRIPTION
Hello, it seems that, clickToSelect=false does not work when expandRow is active,

otherwise it works fine but once you activate expandRow , it is fully ignored and you simpley can't disable all row selection functionality which is something unwanted.

I found, fixed and tested this bug, and it seems to work as expected now. seems like a tiny mistake.

best of luck!