### PR TITLE
[Bug] Expand Indicator is Only Shown for Expandable Rows

### DIFF
--- a/packages/react-bootstrap-table2/src/row.js
+++ b/packages/react-bootstrap-table2/src/row.js
@@ -23,6 +23,7 @@ class Row extends eventDelegater(Component) {
       cellEdit,
       selected,
       selectRow,
+      expandable,
       expanded,
       expandRow,
       selectable,
@@ -48,7 +49,7 @@ class Row extends eventDelegater(Component) {
     return (
       <tr style={ style } className={ className } { ...trAttrs }>
         {
-          showExpandColumn ? (
+          (showExpandColumn && expandable) ? (
             <ExpandCell
               { ...expandRow }
               rowKey={ key }


### PR DESCRIPTION
closes https://github.com/react-bootstrap-table/react-bootstrap-table2/issues/547

@AllenFang 