### PR TITLE
fix #641 typo

### DIFF
--- a/packages/react-bootstrap-table2-filter/src/components/select.js
+++ b/packages/react-bootstrap-table2-filter/src/components/select.js
@@ -86,7 +86,7 @@ class SelectFilter extends Component {
     }
     if (Array.isArray(options)) {
       options.forEach(({ value, label }) =>
-        optionTags.push(<option key={ label } value={ label }>{ value }</option>));
+        optionTags.push(<option key={ value } value={ value }>{ label }</option>));
     } else {
       Object.keys(options).forEach(key =>
         optionTags.push(<option key={ key } value={ key }>{ options[key] }</option>)


### PR DESCRIPTION
You swapped `value` and `label` in the [fix](https://github.com/react-bootstrap-table/react-bootstrap-table2/commit/98a04a57100a2cd9f990ae540e30f16d53a541fa#diff-bd09df04374959a2d6a934ea8059f1bcR89) for #641.

This corrects that swap.

You will also want to update your [docs](https://react-bootstrap-table.github.io/react-bootstrap-table2/storybook/index.html?selectedKind=Column%20Filter&selectedStory=Preserved%20Option%20Order%20on%20Select%20Filter&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel) as it currently uses a swapped example:

```js
const selectOptions = [
  { label: 0, value: 'good' },
  { label: 1, value: 'Bad' },
  { label: 2, value: 'unknown' }
];
```