### PR TITLE
Fix typo in custom-editor doc example code

### DIFF
--- a/packages/react-bootstrap-table2-example/examples/cell-edit/custom-editor-table.js
+++ b/packages/react-bootstrap-table2-example/examples/cell-edit/custom-editor-table.js
@@ -103,7 +103,7 @@ const columns = [{
 }, {
   dataField: 'quality',
   text: 'Product Quality',
-  editorRenderer: (editorProps, value, row, rowIndex, columnIndex) => (
+  editorRenderer: (editorProps, value, row, column, rowIndex, columnIndex) => (
     <QualityRanger { ...editorProps } value={ value } />
   )
 }];


### PR DESCRIPTION
The example code has a typo, the actual code right above is correct.