### PR TITLE
Bootstrap 4 class for Export CSV and Clear Search buttons

### DIFF
--- a/packages/react-bootstrap-table2-toolkit/src/csv/button.js
+++ b/packages/react-bootstrap-table2-toolkit/src/csv/button.js
@@ -26,7 +26,7 @@ ExportCSVButton.propTypes = {
   style: PropTypes.object
 };
 ExportCSVButton.defaultProps = {
-  className: 'react-bs-table-csv-btn btn btn-default',
+  className: 'react-bs-table-csv-btn btn btn-default btn-secondary',
   style: {}
 };
 

--- a/packages/react-bootstrap-table2-toolkit/src/search/clear-button.js
+++ b/packages/react-bootstrap-table2-toolkit/src/search/clear-button.js
@@ -5,7 +5,7 @@ const ClearButton = ({
   onClear,
   text
 }) => (
-  <button className="btn btn-default" onClick={ onClear }>{ text }</button>
+  <button className="btn btn-default btn-secondary" onClick={ onClear }>{ text }</button>
 );
 
 ClearButton.propTypes = {


### PR DESCRIPTION
CSV and Clear Search buttons are missing bootstrap 4 specific class. This PR adds `btn-secondary` class to those two buttons.