### PR TITLE
Fix default prop tableId for SearchBar

### DIFF
--- a/packages/react-bootstrap-table2-toolkit/src/search/SearchBar.js
+++ b/packages/react-bootstrap-table2-toolkit/src/search/SearchBar.js
@@ -96,7 +96,7 @@ SearchBar.defaultProps = {
   placeholder: 'Search',
   delay: 250,
   searchText: '',
-  tableId: 0
+  tableId: '0'
 };
 
 export default SearchBar;


### PR DESCRIPTION
```
index.js:1446 Warning: Failed prop type: Invalid prop `tableId` of type `number` supplied to `SearchBar`, expected `string`.
```

btw it seems like `tableId` is never populated with toolkit provider. At least couldn't find it: https://github.com/react-bootstrap-table/react-bootstrap-table2/search?q=tableId&unscoped_q=tableId