### PR TITLE
Update README, overlayFactory example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -98,7 +98,14 @@ import overlayFactory from 'react-bootstrap-table2-overlay';
 Actually, `react-bootstrap-table-overlay` is depends on [`react-loading-overlay`](https://github.com/derrickpelletier/react-loading-overlay) and `overlayFactory` just a factory function and you can pass any props which available for `react-loading-overlay`:
 
 ```js
-overlay={ overlayFactory({ spinner: true, background: 'rgba(192,192,192,0.3)' }) }
+overlay={
+  overlayFactory({
+    spinner: true,
+    styles: {
+      overlay: (base) => ({...base, background: 'rgba(255, 0, 0, 0.5)'})
+    }
+  })
+}
 ```
 
 ### <a name='caption'>caption - [String | Node]</a>

--- a/packages/react-bootstrap-table2-example/examples/loading-overlay/table-overlay.js
+++ b/packages/react-bootstrap-table2-example/examples/loading-overlay/table-overlay.js
@@ -36,7 +36,7 @@ const RemotePagination = ({ loading, data, page, sizePerPage, onTableChange, tot
       columns={ columns }
       pagination={ paginationFactory({ page, sizePerPage, totalSize }) }
       onTableChange={ onTableChange }
-      overlay={ overlayFactory({ spinner: true, background: 'rgba(192,192,192,0.3)' }) }
+      overlay={ overlayFactory({ spinner: true, styles: { overlay: (base) => ({...base, background: 'rgba(255, 0, 0, 0.5)'}) } }) }
     />
     <Code>{ sourceCode }</Code>
   </div>
@@ -101,7 +101,12 @@ const RemotePagination = ({ loading, data, page, sizePerPage, onTableChange, tot
       columns={ columns }
       pagination={ paginationFactory({ page, sizePerPage, totalSize }) }
       onTableChange={ onTableChange }
-      overlay={ overlayFactory({ spinner: true, background: 'rgba(192,192,192,0.3)' }) }
+      overlay={
+        overlayFactory({
+          spinner: true,
+          styles: { overlay: base => ({ ...base, background: 'rgba(255, 0, 0, 0.5)' }) }
+        })
+      }
     />
     <Code>{ sourceCode }</Code>
   </div>


### PR DESCRIPTION
Why?

Current example `overlayFactory(spinner: true, background: 'red')` does not work.

Solution:

Update example of usage `overlayFactory` according to "react-loading-overlay" [documentation](https://github.com/derrickpelletier/react-loading-overlay#styles-with-emotion-woman_singer) _Custom overlay background (extending base styles)_.

The correct format if:

```js
overlayFactory({
  spinner: true,
  styles: {
    overlay: base => ({ ...base, background: 'rgba(255, 0, 0, 0.5)' })
  }
})
```