### PR TITLE
add rowKey to selectionRenderer function

### DIFF
--- a/packages/react-bootstrap-table2/src/row-selection/selection-cell.js
+++ b/packages/react-bootstrap-table2/src/row-selection/selection-cell.js
@@ -92,7 +92,8 @@ export default class SelectionCell extends Component {
                   mode: inputType,
                   checked: selected,
                   disabled,
-                  rowIndex
+                  rowIndex,
+                  rowKey
                 }) : (
                   <input
                     type={ inputType }

--- a/packages/react-bootstrap-table2/test/row-selection/selection-cell.test.js
+++ b/packages/react-bootstrap-table2/test/row-selection/selection-cell.test.js
@@ -296,7 +296,8 @@ describe('<SelectionCell />', () => {
           mode,
           checked: selected,
           disabled: wrapper.prop('disabled'),
-          rowIndex
+          rowIndex,
+          rowKey: 1
         });
       });
     });


### PR DESCRIPTION
I was writing a custom renderer for the selection cell in order to add a label to the input for screen readers. But I realized that the `rowIndex` being passed in cannot reliably be used to get the row data, since filtering and sorting affect it.

This change merely adds the `rowKey` as an additional param to custom `selectionRenderer` functions.