### PR TITLE
fix: pass actual text to footerFormatter instead of column array

### DIFF
--- a/packages/react-bootstrap-table2/src/footer-cell.js
+++ b/packages/react-bootstrap-table2/src/footer-cell.js
@@ -54,7 +54,7 @@ class FooterCell extends eventDelegater(React.Component) {
     if (cellClasses) cellAttrs.className = cs(cellAttrs.className, cellClasses);
     if (!_.isEmptyObject(cellStyle)) cellAttrs.style = cellStyle;
 
-    const children = footerFormatter ? footerFormatter(column, index) : text;
+    const children = footerFormatter ? footerFormatter(text) : text;
 
     return React.createElement('th', cellAttrs, children);
   }


### PR DESCRIPTION
It doesn't make any sense to receive an array with column items in this function, since this is already done in the "footer" function.

Example: let's say I do just like in the Storybook example:
`const columns = [
{
    dataField: 'price',
    text: 'Product Price',
    footer: columnData => columnData.reduce((acc, item) => acc + item, 0)
  }];`

footFormatter should just receive the result of this already executed function so I can format it.
