### PR TITLE
Avoid exact version lock for classnames package 

### DIFF
--- a/packages/react-bootstrap-table2/package.json
+++ b/packages/react-bootstrap-table2/package.json
@@ -36,7 +36,7 @@
     }
   ],
   "dependencies": {
-    "classnames": "2.2.5",
+    "classnames": "^2.2.5",
     "react-transition-group": "2.5.3",
     "underscore": "1.9.1"
   },


### PR DESCRIPTION
This is an addition to #1107, which missed the version number in this file. So this is still causing issues when using yarn with webpacker.