### PR TITLE
Fix 1185

### DIFF
--- a/packages/react-bootstrap-table2/src/bootstrap-table.js
+++ b/packages/react-bootstrap-table2/src/bootstrap-table.js
@@ -83,7 +83,9 @@ class BootstrapTable extends PropsBaseResolver(Component) {
 
     const hasFooter = _.filter(columns, col => _.has(col, 'footer')).length > 0;
 
-    const tableCaption = (caption && <Caption>{ caption }</Caption>);
+    const tableCaption = (
+      caption && <Caption bootstrap4={ bootstrap4 }>{ caption }</Caption>
+    );
 
     return (
       <div className={ tableWrapperClass }>

--- a/packages/react-bootstrap-table2/src/caption.js
+++ b/packages/react-bootstrap-table2/src/caption.js
@@ -4,16 +4,22 @@ import PropTypes from 'prop-types';
 
 const Caption = (props) => {
   if (!props.children) return null;
-  return (
-    <caption>{ props.children }</caption>
+
+  const caption = props.bootstrap4 ? (
+    <caption style={ { captionSide: 'top' } }>{props.children}</caption>
+  ) : (
+    <caption>{props.children}</caption>
   );
+
+  return caption;
 };
 
 Caption.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.string
-  ])
+  ]),
+  bootstrap4: PropTypes.bool
 };
 
 export default Caption;


### PR DESCRIPTION
### Fix Issue #1185 

Bootstrap 4 has default caption CSS `caption-side: bottom`

Caption component was updated in order to receive a new prop to check if bootstrap 4 is in use,
if it is in use a custom caption with `caption-side: top` is rendered.