### PR TITLE
Adds onKeyUp event to header for sort

### DIFF
--- a/packages/react-bootstrap-table2/src/header-cell.js
+++ b/packages/react-bootstrap-table2/src/header-cell.js
@@ -77,6 +77,12 @@ class HeaderCell extends eventDelegater(React.Component) {
 
     if (sort) {
       const customClick = cellAttrs.onClick;
+      cellAttrs.onKeyUp = (e) => {
+        if (e.key === 'Enter') {
+          onSort(column);
+          if (_.isFunction(customClick)) customClick(e);
+        }
+      };
       cellAttrs.onClick = (e) => {
         onSort(column);
         if (_.isFunction(customClick)) customClick(e);

--- a/packages/react-bootstrap-table2/test/header-cell.test.js
+++ b/packages/react-bootstrap-table2/test/header-cell.test.js
@@ -393,7 +393,7 @@ describe('HeaderCell', () => {
     it('should have onClick event on header cell', () => {
       expect(wrapper.find('th').prop('onClick')).toBeDefined();
     });
-    
+
     it('should have onKeyUp event on header cell', () => {
       expect(wrapper.find('th').prop('onKeyUp')).toBeDefined();
     });
@@ -404,12 +404,12 @@ describe('HeaderCell', () => {
     });
 
     it('should trigger onSort callback when keyup Enter on header cell', () => {
-      wrapper.find('th').simulate('keyup', {key: 'Enter'});
+      wrapper.find('th').simulate('keyup', { key: 'Enter' });
       expect(onSortCallBack.callCount).toBe(1);
     });
 
     it('should not trigger onSort callback when keyup key is not Enter on header cell', () => {
-      wrapper.find('th').simulate('keyup', {key: 'test-key'});
+      wrapper.find('th').simulate('keyup', { key: 'test-key' });
       expect(onSortCallBack.callCount).toBe(0);
     });
 

--- a/packages/react-bootstrap-table2/test/header-cell.test.js
+++ b/packages/react-bootstrap-table2/test/header-cell.test.js
@@ -393,10 +393,24 @@ describe('HeaderCell', () => {
     it('should have onClick event on header cell', () => {
       expect(wrapper.find('th').prop('onClick')).toBeDefined();
     });
+    
+    it('should have onKeyUp event on header cell', () => {
+      expect(wrapper.find('th').prop('onKeyUp')).toBeDefined();
+    });
 
     it('should trigger onSort callback when click on header cell', () => {
       wrapper.find('th').simulate('click');
       expect(onSortCallBack.callCount).toBe(1);
+    });
+
+    it('should trigger onSort callback when keyup Enter on header cell', () => {
+      wrapper.find('th').simulate('keyup', {key: 'Enter'});
+      expect(onSortCallBack.callCount).toBe(1);
+    });
+
+    it('should not trigger onSort callback when keyup key is not Enter on header cell', () => {
+      wrapper.find('th').simulate('keyup', {key: 'test-key'});
+      expect(onSortCallBack.callCount).toBe(0);
     });
 
     describe('and sorting prop is false', () => {


### PR DESCRIPTION
- Adds onKeyUp event to aid in ADA compliance

Needed for keyboard navigation. Current functionality does not allow a user to sort with their keyboard,

Still doesn't call out ascending or descending order on a screen reader but I felt like this was a start.

#1238