### PR TITLE
Animation v2

### DIFF
--- a/packages/react-bootstrap-table2-example/examples/row-expand/disable-animation.js
+++ b/packages/react-bootstrap-table2-example/examples/row-expand/disable-animation.js
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import BootstrapTable from 'react-bootstrap-table-next';
+import Code from 'components/common/code-block';
+import { productsExpandRowsGenerator } from 'utils/common';
+
+const products = productsExpandRowsGenerator();
+
+const columns = [{
+  dataField: 'id',
+  text: 'Product ID'
+}, {
+  dataField: 'name',
+  text: 'Product Name'
+}, {
+  dataField: 'price',
+  text: 'Product Price'
+}];
+
+const expandRow = {
+  renderer: (row, rowIndex) => (
+    <div>
+      <p>{ `This Expand row is belong to rowKey ${row.id} and index: ${rowIndex}` }</p>
+      <p>You can render anything here, also you can add additional data on every row object</p>
+      <p>expandRow.renderer callback will pass the origin row object to you</p>
+    </div>
+  ),
+  animate: false
+};
+
+const sourceCode = `\
+import BootstrapTable from 'react-bootstrap-table-next';
+
+const columns = [{
+  dataField: 'id',
+  text: 'Product ID'
+}, {
+  dataField: 'name',
+  text: 'Product Name'
+}, {
+  dataField: 'price',
+  text: 'Product Price'
+}];
+
+const expandRow = {
+  renderer: row => (
+    <div>
+      <p>{ \`This Expand row is belong to rowKey $\{row.id}\` }</p>
+      <p>You can render anything here, also you can add additional data on every row object</p>
+      <p>expandRow.renderer callback will pass the origin row object to you</p>
+    </div>
+  ), 
+  animate: false
+};
+
+<BootstrapTable
+  keyField='id'
+  data={ products }
+  columns={ columns }
+  expandRow={ expandRow }
+/>
+`;
+
+export default () => (
+  <div>
+    <BootstrapTable
+      keyField="id"
+      data={ products }
+      columns={ columns }
+      expandRow={ expandRow }
+    />
+    <Code>{ sourceCode }</Code>
+  </div>
+);

--- a/packages/react-bootstrap-table2-example/stories/index.js
+++ b/packages/react-bootstrap-table2-example/stories/index.js
@@ -165,6 +165,7 @@ import SelectionColumnPositionTable from 'examples/row-selection/selection-colum
 
 // work on row expand
 import BasicRowExpand from 'examples/row-expand';
+import DisableExpandAnimation from 'examples/row-expand/disable-animation';
 import RowExpandManagement from 'examples/row-expand/expand-management';
 import NonExpandableRows from 'examples/row-expand/non-expandable-rows';
 import ExpandColumn from 'examples/row-expand/expand-column';
@@ -429,6 +430,7 @@ storiesOf('Row Selection', module)
 storiesOf('Row Expand', module)
   .addDecorator(bootstrapStyle())
   .add('Basic Row Expand', () => <BasicRowExpand />)
+  .add('Disable Expand Animation', () => <DisableExpandAnimation />)
   .add('Expand Management', () => <RowExpandManagement />)
   .add('Non Expandabled Rows', () => <NonExpandableRows />)
   .add('Expand Indicator', () => <ExpandColumn />)

--- a/packages/react-bootstrap-table2/src/bootstrap-table.js
+++ b/packages/react-bootstrap-table2/src/bootstrap-table.js
@@ -207,6 +207,7 @@ BootstrapTable.propTypes = {
   }),
   expandRow: PropTypes.shape({
     renderer: PropTypes.func,
+    animate: PropTypes.bool,
     expanded: PropTypes.array,
     onExpand: PropTypes.func,
     onExpandAll: PropTypes.func,
@@ -273,6 +274,7 @@ BootstrapTable.defaultProps = {
   },
   expandRow: {
     renderer: undefined,
+    animate: true,
     expanded: [],
     nonExpandable: []
   },

--- a/packages/react-bootstrap-table2/src/row-expand/expand-row.js
+++ b/packages/react-bootstrap-table2/src/row-expand/expand-row.js
@@ -7,7 +7,6 @@ const ExpandRow = ({ children, expanded, onClosed, className, ...rest }) => (
   <tr>
     <td className={ cs('reset-expansion-style', className) } { ...rest }>
       <CSSTransition
-        appear
         in={ expanded }
         timeout={ 400 }
         classNames="row-expand-slide"

--- a/packages/react-bootstrap-table2/src/row-expand/expand-row.js
+++ b/packages/react-bootstrap-table2/src/row-expand/expand-row.js
@@ -4,9 +4,6 @@ import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 
 export default class ExpandRow extends React.Component {
-  constructor(props) {
-    super(props);
-  }
   onEnter() {
     this.expandableDiv = document.getElementById(`expansion-div-${this.props.id}`);
     if (!this.elementHeight) {

--- a/packages/react-bootstrap-table2/src/row-expand/expand-row.js
+++ b/packages/react-bootstrap-table2/src/row-expand/expand-row.js
@@ -16,27 +16,44 @@ export default class ExpandRow extends React.Component {
   onExit() {
     this.expandableDiv.style.height = '0px';
   }
+  componentDidUpdate(prevProps){
+    if (!this.props.animate && !this.props.expanded && prevProps.expanded !== this.props.expanded) {
+      this.props.onClosed();
+    }
+  }
   render() {
-    const { children, expanded, onClosed, className, id, ...rest } = this.props;
+    const { children, expanded, onClosed, className, id, animate, ...rest } = this.props;
+
+    let expansionDiv = (
+      <div id={ `expansion-div-${id}` } className="row-expansion-inner">
+        <div className="row-expansion-style">
+          {children}
+        </div>
+      </div>
+    );
+
+    if (animate) {
+      expansionDiv = (
+        <Transition
+          in={ expanded }
+          timeout={ 460 }
+          onEnter={ () => this.onEnter() }
+          onExit={ () => this.onExit() }
+          onExited={ onClosed }
+          unmountOnExit
+        >
+          {expansionDiv}
+        </Transition>
+      );
+    }
+
     return (
       <tr>
         <td className={ cs('reset-expansion-style', className) } { ...rest }>
-          <Transition
-            in={ expanded }
-            timeout={ 460 }
-            onEnter={ () => this.onEnter() }
-            onExit={ () => this.onExit() }
-            onExited={ onClosed }
-            unmountOnExit
-          >
-            <div id={ `expansion-div-${id}` } className="row-expansion-inner">
-              <div className="row-expansion-style">
-                {children}
-              </div>
-            </div>
-          </Transition>
+          {expansionDiv}
         </td>
-      </tr>);
+      </tr>
+    );
   }
 }
 
@@ -45,6 +62,7 @@ ExpandRow.propTypes = {
   expanded: PropTypes.bool,
   onClosed: PropTypes.func,
   className: PropTypes.string,
+  animate: PropTypes.bool,
   id: PropTypes.number
 };
 
@@ -53,5 +71,6 @@ ExpandRow.defaultProps = {
   expanded: false,
   onClosed: null,
   className: '',
+  animate: true,
   id: null
 };

--- a/packages/react-bootstrap-table2/src/row-expand/expand-row.js
+++ b/packages/react-bootstrap-table2/src/row-expand/expand-row.js
@@ -6,12 +6,12 @@ import { Transition } from 'react-transition-group';
 export default class ExpandRow extends React.Component {
   constructor(props) {
     super(props);
-
-    this.elementHeight = 0;
   }
   onEnter() {
     this.expandableDiv = document.getElementById(`expansion-div-${this.props.id}`);
-    this.elementHeight = this.expandableDiv.offsetHeight;
+    if (!this.elementHeight) {
+      this.elementHeight = this.expandableDiv.offsetHeight;
+    }
     this.expandableDiv.style.height = '0px';
     const elementHeight = this.elementHeight;
     setTimeout(() => { this.expandableDiv.style.height = `${elementHeight}px`; }, 1);
@@ -48,7 +48,7 @@ ExpandRow.propTypes = {
   expanded: PropTypes.bool,
   onClosed: PropTypes.func,
   className: PropTypes.string,
-  id: PropTypes.string
+  id: PropTypes.number
 };
 
 ExpandRow.defaultProps = {
@@ -56,5 +56,5 @@ ExpandRow.defaultProps = {
   expanded: false,
   onClosed: null,
   className: '',
-  id: ''
+  id: null
 };

--- a/packages/react-bootstrap-table2/src/row-expand/expand-row.js
+++ b/packages/react-bootstrap-table2/src/row-expand/expand-row.js
@@ -1,39 +1,60 @@
 import cs from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CSSTransition } from 'react-transition-group';
+import { Transition } from 'react-transition-group';
 
-const ExpandRow = ({ children, expanded, onClosed, className, ...rest }) => (
-  <tr>
-    <td className={ cs('reset-expansion-style', className) } { ...rest }>
-      <CSSTransition
-        in={ expanded }
-        timeout={ 400 }
-        classNames="row-expand-slide"
-        onExited={ onClosed }
-      >
-        <div>
-          <div className="row-expansion-style">
-            { children }
-          </div>
-        </div>
-      </CSSTransition>
-    </td>
-  </tr>
-);
+export default class ExpandRow extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.elementHeight = 0;
+  }
+  onEnter() {
+    this.expandableDiv = document.getElementById(`expansion-div-${this.props.id}`);
+    this.elementHeight = this.expandableDiv.offsetHeight;
+    this.expandableDiv.style.height = '0px';
+    const elementHeight = this.elementHeight;
+    setTimeout(() => { this.expandableDiv.style.height = `${elementHeight}px`; }, 1);
+  }
+  onExit() {
+    this.expandableDiv.style.height = '0px';
+  }
+  render() {
+    const { children, expanded, onClosed, className, id, ...rest } = this.props;
+    return (
+      <tr>
+        <td className={ cs('reset-expansion-style', className) } { ...rest }>
+          <Transition
+            in={ expanded }
+            timeout={ 460 }
+            onEnter={ () => this.onEnter() }
+            onExit={ () => this.onExit() }
+            onExited={ onClosed }
+            unmountOnExit
+          >
+            <div id={ `expansion-div-${id}` } className="row-expansion-inner">
+              <div className="row-expansion-style">
+                {children}
+              </div>
+            </div>
+          </Transition>
+        </td>
+      </tr>);
+  }
+}
 
 ExpandRow.propTypes = {
   children: PropTypes.node,
   expanded: PropTypes.bool,
   onClosed: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
+  id: PropTypes.string
 };
 
 ExpandRow.defaultProps = {
   children: null,
   expanded: false,
   onClosed: null,
-  className: ''
+  className: '',
+  id: ''
 };
-
-export default ExpandRow;

--- a/packages/react-bootstrap-table2/src/row-expand/row-consumer.js
+++ b/packages/react-bootstrap-table2/src/row-expand/row-consumer.js
@@ -34,6 +34,7 @@ export default (Component) => {
         className={ cs(props.className, parentClassName) }
       />,
       expanded || isClosing ? <ExpandRow
+        id={ key }
         key={ `${key}-expanding` }
         colSpan={ props.visibleColumnSize }
         expanded={ expanded }

--- a/packages/react-bootstrap-table2/src/row-expand/row-consumer.js
+++ b/packages/react-bootstrap-table2/src/row-expand/row-consumer.js
@@ -36,6 +36,7 @@ export default (Component) => {
       expanded || isClosing ? <ExpandRow
         id={ key }
         key={ `${key}-expanding` }
+        animate={ expandRow.animate }
         colSpan={ props.visibleColumnSize }
         expanded={ expanded }
         onClosed={ () => expandRow.onClosed(key) }

--- a/packages/react-bootstrap-table2/style/react-bootstrap-table2.scss
+++ b/packages/react-bootstrap-table2/style/react-bootstrap-table2.scss
@@ -163,20 +163,8 @@
   .row-expansion-style{
     padding: 8px;
   }
-  .row-expand-slide-enter{
-    max-height: 0;
+  .row-expansion-inner{
+    transition: height 0.5s ease;
     overflow: hidden;
-  }
-  .row-expand-slide-enter-active{
-    max-height: 1000px;
-    transition: max-height 3s linear;
-  }
-  .row-expand-slide-exit{
-    max-height: 1000px;
-  }
-  .row-expand-slide-exit-active{
-    max-height: 0;
-    overflow: hidden;
-    transition: max-height 400ms cubic-bezier(0, 0.95, 0, 0.95)
   }
 }

--- a/packages/react-bootstrap-table2/style/react-bootstrap-table2.scss
+++ b/packages/react-bootstrap-table2/style/react-bootstrap-table2.scss
@@ -163,11 +163,11 @@
   .row-expansion-style{
     padding: 8px;
   }
-  .row-expand-slide-appear{
+  .row-expand-slide-enter{
     max-height: 0;
     overflow: hidden;
   }
-  .row-expand-slide-appear-active{
+  .row-expand-slide-enter-active{
     max-height: 1000px;
     transition: max-height 3s linear;
   }


### PR DESCRIPTION
Improved row expansion animation (#912):
 - Smoother animation
 - Can handle any content height without looking weird
 - Added `animate` prop to disable animation (true by default)

Added storybook page for `animate` prop

Further testing would be appreciated.