### PR TITLE
Update keyField/data props Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,10 +39,35 @@
 * [onDataSizeChange](#onDataSizeChange)
 
 ### <a name='keyField'>keyField(**required**) - [String]</a>
-Tells `react-bootstrap-table2` which column is unique.
+Tells `react-bootstrap-table2` which column of the data is unique. This should be the name of a property that is unique for each item in your dataset
 
 ### <a name='data'>data(**required**) - [Array]</a>
 Provides data for your table. It accepts a single Array object.
+
+Each item in this array is an object that represents a row in the table. Each "Row" object should have a key-value pair for each column in the table, whose key matches that column's dataField value.
+
+For example, if your column definitions look like:
+
+```js
+columns = [
+  { dataField: 'id', text: 'Id' },
+  { dataField: 'name', text: 'Name' },
+  { dataField: 'animal', text: 'Animal' },
+]
+```
+
+Then your data might look like:
+
+```js
+data = [
+  { id: 1, name: 'George', animal: 'Monkey' }
+  { id: 2, name: 'Jeffrey', animal: 'Giraffe' }
+  { id: 3, name: 'Alice', animal: 'Giraffe' }
+  { id: 4, name: 'Alice', animal: 'Tiger' }
+]
+```
+
+And your "keyField" would be `id`
 
 ### <a name='columns'>columns(**required**) - [Object]</a>
 Accepts a single Array object, please see [columns definition](./columns.md) for more detail.


### PR DESCRIPTION
I added more info to the descriptions of the keyField and data props of
the Table component. I also added an example of what these properties
might look like for a sample dataset.

I couldn't find any info in the documentation about how the data should be formatted or what that should look like (I found a medium post that explained it well), and I had to read the source code to understand what the keyField was for. I think having better descriptions of these props in the documentation will be helpful to users.