### PR TITLE
Get value from key first; if not existing, try recursive get

### DIFF
--- a/packages/react-bootstrap-table2/src/utils.js
+++ b/packages/react-bootstrap-table2/src/utils.js
@@ -12,6 +12,11 @@ function splitNested(str) {
 }
 
 function get(target, field) {
+  const directGet = target[field];
+  if (directGet !== undefined && directGet !== null) {
+    return directGet;
+  }
+
   const pathArray = splitNested(field);
   let result;
   try {

--- a/packages/react-bootstrap-table2/test/utils.test.js
+++ b/packages/react-bootstrap-table2/test/utils.test.js
@@ -10,7 +10,8 @@ describe('Utils', () => {
         city: {
           name: 'B'
         }
-      }
+      },
+      'person.name': 'John Doe'
     };
 
     it('should return correct data', () => {
@@ -19,6 +20,7 @@ describe('Utils', () => {
       expect(_.get(data, 'address.city.name')).toEqual(data.address.city.name);
       expect(_.get(data, 'address.notExist')).toEqual(undefined);
       expect(_.get(data, 'address.not.exist')).toEqual(undefined);
+      expect(_.get(data, 'person.name')).toEqual(data['person.name']);
     });
   });
 


### PR DESCRIPTION
Due to splitting object field by dot (.), when an user provides a data
which key has a dot, it will cause an issue for an `undefined` data
which looks like not rendered.

So, to solve this, we should try to get the object value from the key
first. If it's not defined or null, then we will try to do the original
recursive way to get value.

Fix #1381 