### PR TITLE
PaginatonList: Use title as key for buttons

### DIFF
--- a/packages/react-bootstrap-table2-paginator/src/pagination-list.js
+++ b/packages/react-bootstrap-table2-paginator/src/pagination-list.js
@@ -15,7 +15,7 @@ const PaginatonList = props => (
         }
         return (
           <PageButton
-            key={ pageProps.page }
+            key={ pageProps.title }
             { ...pageProps }
             onPageChange={ props.onPageChange }
           />


### PR DESCRIPTION
Using icon (React Element) as `firstPageText` and another of last/next/pre causes this error,

> Warning: Encountered two children with the same key, `[object Object]`. Keys should be unique so that components maintain their identity across updates.

This is because we are trying to use page button label `pageProps.page` as key, documents suggest it can be **any**thing (which should include React element),
https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/pagination-props.html#paginationfirstpagetext-any

Hence, I believe it makes more sense to use `title` as key.

My use case is something like this,
![image](https://user-images.githubusercontent.com/11048263/91301323-4b90ff00-e7d7-11ea-9cc8-2de7e3f7812e.png)

I have for now resolved it for myself using a custom `pageButtonRenderer`.