### PR TITLE
feat: add array union and intersection functionality to multiselect filter

### DIFF
--- a/packages/react-bootstrap-table2-filter/src/filter.js
+++ b/packages/react-bootstrap-table2-filter/src/filter.js
@@ -171,14 +171,18 @@ export const filterByDate = _ => (
 export const filterByArray = _ => (
   data,
   dataField,
-  { filterVal, comparator }
+  { filterVal, comparator },
+  customFilterValue
 ) => {
   if (filterVal.length === 0) return data;
   const refinedFilterVal = filterVal
     .filter(x => _.isDefined(x))
     .map(x => x.toString());
   return data.filter((row) => {
-    const cell = _.get(row, dataField);
+    let cell = _.get(row, dataField);
+    if (customFilterValue) {
+      cell = customFilterValue(cell, row);
+    }
     if (Array.isArray(cell)) {
       if (comparator === EQ) {
         return refinedFilterVal.length === cell.length

--- a/packages/react-bootstrap-table2-filter/src/filter.js
+++ b/packages/react-bootstrap-table2-filter/src/filter.js
@@ -179,6 +179,14 @@ export const filterByArray = _ => (
     .map(x => x.toString());
   return data.filter((row) => {
     const cell = _.get(row, dataField);
+    if (Array.isArray(cell)) {
+      if (comparator === EQ) {
+        return refinedFilterVal.length === cell.length
+          && refinedFilterVal.every((val, i) => val === cell[i].toString());
+      }
+      const lookup = new Set(refinedFilterVal);
+      return cell.some(val => lookup.has(val.toString()));
+    }
     let cellStr = _.isDefined(cell) ? cell.toString() : '';
     if (comparator === EQ) {
       return refinedFilterVal.indexOf(cellStr) !== -1;

--- a/packages/react-bootstrap-table2-filter/test/filter.test.js
+++ b/packages/react-bootstrap-table2-filter/test/filter.test.js
@@ -128,31 +128,72 @@ describe('filter', () => {
     });
 
     describe('when filter value is not an empty array', () => {
-      describe(`and comparator is ${EQ}`, () => {
-        it('should return data correctly', () => {
-          currFilters.price = {
-            filterVal: [201, 203],
-            filterType: FILTER_TYPE.MULTISELECT,
-            comparator: EQ
-          };
+      describe('and the cell is a value', () => {
+        describe(`and comparator is ${EQ}`, () => {
+          it('should return data correctly', () => {
+            currFilters.price = {
+              filterVal: [201, 203],
+              filterType: FILTER_TYPE.MULTISELECT,
+              comparator: EQ
+            };
 
-          const result = filters(data, columns, _)(currFilters);
-          expect(result).toBeDefined();
-          expect(result).toHaveLength(2);
+            const result = filters(data, columns, _)(currFilters);
+            expect(result).toBeDefined();
+            expect(result).toHaveLength(2);
+          });
+        });
+
+        describe(`and comparator is ${LIKE}`, () => {
+          it('should return data correctly', () => {
+            currFilters.name = {
+              filterVal: ['name 3', '5'],
+              filterType: FILTER_TYPE.MULTISELECT,
+              comparator: LIKE
+            };
+
+            const result = filters(data, columns, _)(currFilters);
+            expect(result).toBeDefined();
+            expect(result).toHaveLength(3);
+          });
         });
       });
 
-      describe(`and comparator is ${LIKE}`, () => {
-        it('should return data correctly', () => {
-          currFilters.name = {
-            filterVal: ['name 3', '5'],
-            filterType: FILTER_TYPE.MULTISELECT,
-            comparator: LIKE
-          };
+      describe('and the cell is an array', () => {
+        const arrayData = new Array(500)
+          .fill(0)
+          .map((v, i) => ({ price: [i, i + 2] }));
 
-          const result = filters(data, columns, _)(currFilters);
-          expect(result).toBeDefined();
-          expect(result).toHaveLength(3);
+        const arrayDataColumns = [{
+          dataField: 'price',
+          text: 'Price'
+        }];
+
+        describe(`and comparator is ${EQ}`, () => {
+          it('should return data correctly', () => {
+            currFilters.price = {
+              filterVal: [201, 203],
+              filterType: FILTER_TYPE.MULTISELECT,
+              comparator: EQ
+            };
+
+            const result = filters(arrayData, arrayDataColumns, _)(currFilters);
+            expect(result).toBeDefined();
+            expect(result).toHaveLength(1);
+          });
+        });
+
+        describe(`and comparator is ${LIKE}`, () => {
+          it('should return data correctly', () => {
+            currFilters.price = {
+              filterVal: [201, 203],
+              filterType: FILTER_TYPE.MULTISELECT,
+              comparator: LIKE
+            };
+
+            const result = filters(arrayData, arrayDataColumns, _)(currFilters);
+            expect(result).toBeDefined();
+            expect(result).toHaveLength(3);
+          });
         });
       });
     });


### PR DESCRIPTION
This PR adds the ability to compare array values against an array filter using the multi-select filter mode. This change is implemented by automatically detecting if the value contained in `cell` is an array, and if so applying different array-based comparison logic: `EQ` checks for complete equality, and `LIKE` checks that any value in the filtered values are present in the cells. I've added this feature to allow for filtering sets such as GitHub issue labels, where an issue/pr will have many labels and a user can specify which issue/pr labels they would like to filter by.