### PR TITLE
Adding `classnames` as a dependency for Yarn PnP

### DIFF
--- a/packages/react-bootstrap-table2-paginator/package.json
+++ b/packages/react-bootstrap-table2-paginator/package.json
@@ -36,6 +36,9 @@
       "url": "https://github.com/Chun-MingChen"
     }
   ],
+  "dependencies": {
+    "classnames": "^2.2.6"
+  },
   "peerDependencies": {
     "prop-types": "^15.0.0",
     "react": "^16.3.0",


### PR DESCRIPTION
Yarn V2 refuses access to packages which are not listed as a dependency. This should help fix it.

Details here: https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies