### PR TITLE
remove handleDebounce incorrect arguments from arrow functions

### DIFF
--- a/packages/react-bootstrap-table2-toolkit/src/search/SearchBar.js
+++ b/packages/react-bootstrap-table2-toolkit/src/search/SearchBar.js
@@ -22,7 +22,7 @@ const handleDebounce = (func, wait, immediate) => {
     timeout = setTimeout(later, wait || 0);
 
     if (callNow) {
-      func.appy(this, args);
+      func.apply(this, args);
     }
   };
 };

--- a/packages/react-bootstrap-table2-toolkit/src/search/SearchBar.js
+++ b/packages/react-bootstrap-table2-toolkit/src/search/SearchBar.js
@@ -6,12 +6,12 @@ import PropTypes from 'prop-types';
 const handleDebounce = (func, wait, immediate) => {
   let timeout;
 
-  return () => {
+  return (...args) => {
     const later = () => {
       timeout = null;
 
       if (!immediate) {
-        func.apply(this, arguments);
+        func.apply(this, args);
       }
     };
 
@@ -22,7 +22,7 @@ const handleDebounce = (func, wait, immediate) => {
     timeout = setTimeout(later, wait || 0);
 
     if (callNow) {
-      func.appy(this, arguments);
+      func.appy(this, args);
     }
   };
 };


### PR DESCRIPTION
### Temporary workaround, for anyone who may come across this issue before this PR is merged:
use `import ToolkitProvider from 'react-bootstrap-table2-toolkit/dist/react-bootstrap-table2-toolkit.min';` instead.

------
**Problem addressed:**
As seen in [MDN's web docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions), an arrow function... 
> "Does not have arguments, or new.target keywords."

leading to this error when trying to import the toolkit package.

![image](https://user-images.githubusercontent.com/2107110/98620345-22124a80-22d3-11eb-9d2b-75ac3a534448.png)

`Uncaught ReferenceError: arguments is not defined`

------
Edit for housekeeping: closes #1520



