### PR TITLE
Fix: add custom styles at header column when select all is disabled

### DIFF
--- a/packages/react-bootstrap-table2/src/row-selection/selection-header-cell.js
+++ b/packages/react-bootstrap-table2/src/row-selection/selection-header-cell.js
@@ -73,23 +73,25 @@ export default class SelectionHeaderCell extends Component {
       hideSelectAll,
       headerColumnStyle
     } = this.props;
+
+    const attrs = {};
+
+    attrs.style = _.isFunction(headerColumnStyle) ?
+      headerColumnStyle(checkedStatus) :
+      headerColumnStyle;
+
     if (hideSelectAll) {
-      return <th data-row-selection />;
+      return <th data-row-selection { ...attrs } />;
     }
 
     const checked = checkedStatus === CHECKBOX_STATUS_CHECKED;
 
     const indeterminate = checkedStatus === CHECKBOX_STATUS_INDETERMINATE;
 
-    const attrs = {};
     let content;
     if (selectionHeaderRenderer || mode === ROW_SELECT_MULTIPLE) {
       attrs.onClick = this.handleCheckBoxClick;
     }
-
-    attrs.style = _.isFunction(headerColumnStyle) ?
-      headerColumnStyle(checkedStatus) :
-      headerColumnStyle;
 
     return (
       <BootstrapContext.Consumer>


### PR DESCRIPTION
When trying to apply custom styles to the header column following [the docs](https://react-bootstrap-table.github.io/react-bootstrap-table2/docs/row-select-props.html#selectrowheadercolumnstyle-object-function), I found this didn't work when the option `hideSelectAll` is set to `true`. This commit fixes this just re-arranging the code so that it applies the custom styles also for this case.