### PR TITLE
add isRowHeader to columns

### DIFF
--- a/docs/columns.md
+++ b/docs/columns.md
@@ -8,6 +8,7 @@ Available properties in a column object:
 
 #### Optional
 * [isDummyField](#isDummyField)
+* [isRowHeader](#isRowHeader)
 * [hidden](#hidden)
 * [formatter](#formatter)
 * [formatExtraData](#formatExtraData)
@@ -134,6 +135,10 @@ The third argument: `components` have following specified properties:
 
 ## <a name='formatExtraData'>column.formatExtraData - [Any]</a>
 It's only used for [`column.formatter`](#formatter), you can define any value for it and will be passed as fourth argument for [`column.formatter`](#formatter) callback function.
+
+## <a name='isRowHeader'>column.isRowHeader - [Bool]</a>
+Specify if the column should be a row header. If `true`, the cells will be rendered as `<th>` tags, 
+otherwise they will be rendered as the default `<td>`.
 
 ## <a name='type'>column.type - [String]</a>
 Specify the data type on column. Available value so far is `string`, `number`, `bool` and `date`. Default is `string`.   

--- a/docs/row-expand.md
+++ b/docs/row-expand.md
@@ -20,6 +20,7 @@
 * [expandHeaderColumnRenderer](#expandHeaderColumnRenderer)
 * [className](#className)
 * [parentClassName](#parentClassName)
+* [isRowHeader](#isRowHeader)
 
 ### <a name="renderer">expandRow.renderer - [Function]</a>
 
@@ -210,3 +211,7 @@ const expandRow = {
   }
 };
 ```
+
+## <a name='isRowHeader'>column.isRowHeader - [Bool]</a>
+Specify if the expamsion column should be a row header. If `true`, the cells will be rendered as `<th>` tags, 
+otherwise they will be rendered as the default `<td>`.

--- a/docs/row-selection.md
+++ b/docs/row-selection.md
@@ -9,6 +9,7 @@
 * [selected](#selected)
 * [style](#style)
 * [classes)](#classes)
+* [isRowHeader](#isRowHeader)
 * [bgColor](#bgColor)
 * [nonSelectable)](#nonSelectable)
 * [nonSelectableStyle](#nonSelectableStyle)
@@ -109,6 +110,10 @@ const selectRow = {
   classes: (row, rowIndex) => { return ...; }
 };
 ```
+
+## <a name='isRowHeader'>column.isRowHeader - [Bool]</a>
+Specify if the selection column should be a row header. If `true`, the cells will be rendered as `<th>` tags, 
+otherwise they will be rendered as the default `<td>`.
 
 ### <a name='bgColor'>selectRow.bgColor - [String | Function]</a>
 The background color when row is selected

--- a/packages/react-bootstrap-table2-example/examples/basic/is-row-header.js
+++ b/packages/react-bootstrap-table2-example/examples/basic/is-row-header.js
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import BootstrapTable from 'react-bootstrap-table-next';
+import Code from 'components/common/code-block';
+import { productsGenerator } from 'utils/common';
+
+const products = productsGenerator();
+
+const columns = [{
+  dataField: 'name',
+  text: 'Product Name',
+  isRowHeader: true,
+  attrs: { scope: 'col' },
+  headerAttrs: { scope: 'row' }
+}, {
+  dataField: 'id',
+  text: 'Product ID',
+  headerAttrs: { scope: 'row' }
+}, {
+  dataField: 'price',
+  text: 'Product Price',
+  headerAttrs: { scope: 'row' }
+}];
+
+const sourceCode = `\
+import BootstrapTable from 'react-bootstrap-table-next';
+
+const columns = [{
+  dataField: 'id',
+  text: 'Product ID',
+  headerAttrs: { scope: 'row' }
+}, {
+  dataField: 'name',
+  text: 'Product Name',
+  isRowHeader: true,
+  attrs: { scope: 'col' },
+  headerAttrs: { scope: 'row' }
+}, {
+  dataField: 'price',
+  text: 'Product Price',
+  headerAttrs: { scope: 'row' }
+}];
+
+<BootstrapTable keyField='id' data={ products } columns={ columns } />
+`;
+
+export default () => (
+  <div>
+    <BootstrapTable keyField="id" data={ products } columns={ columns } />
+    <Code>{ sourceCode }</Code>
+  </div>
+);

--- a/packages/react-bootstrap-table2-example/stories/index.js
+++ b/packages/react-bootstrap-table2-example/stories/index.js
@@ -7,6 +7,7 @@ import Welcome from 'examples/welcome';
 
 // basic
 import BasicTable from 'examples/basic';
+import RowHeaderTable from 'examples/basic/is-row-header';
 import BorderlessTable from 'examples/basic/borderless-table';
 import StripHoverCondensedTable from 'examples/basic/striped-hover-condensed-table';
 import NoDataTable from 'examples/basic/no-data-table';
@@ -261,6 +262,7 @@ storiesOf('Welcome', module).add('react bootstrap table 2 ', () => <Welcome />);
 storiesOf('Basic Table', module)
   .addDecorator(bootstrapStyle())
   .add('basic table', () => <BasicTable />)
+  .add('with row header', () => <RowHeaderTable />)
   .add('striped, hover, condensed table', () => <StripHoverCondensedTable />)
   .add('borderless table', () => <BorderlessTable />)
   .add('Indication For Empty Table', () => <NoDataTable />)

--- a/packages/react-bootstrap-table2/src/cell.js
+++ b/packages/react-bootstrap-table2/src/cell.js
@@ -17,8 +17,8 @@ class Cell extends eventDelegater(Component) {
       shouldUpdate = !_.isEqual(this.props.row, nextProps.row);
     } else {
       shouldUpdate =
-        _.get(this.props.row, this.props.column.dataField)
-          !== _.get(nextProps.row, nextProps.column.dataField);
+        _.get(this.props.row, this.props.column.dataField) !==
+        _.get(nextProps.row, nextProps.column.dataField);
     }
 
     if (shouldUpdate) return true;
@@ -26,7 +26,10 @@ class Cell extends eventDelegater(Component) {
     // if (nextProps.formatter)
 
     shouldUpdate =
-      (nextProps.column.formatter ? !_.isEqual(this.props.row, nextProps.row) : false) ||
+      (nextProps.column.formatter
+        ? !_.isEqual(this.props.row, nextProps.row)
+        : false) ||
+      this.props.column.isRowHeader !== nextProps.column.isRowHeader ||
       this.props.column.hidden !== nextProps.column.hidden ||
       this.props.column.isDummyField !== nextProps.column.isDummyField ||
       this.props.rowIndex !== nextProps.rowIndex ||
@@ -37,7 +40,10 @@ class Cell extends eventDelegater(Component) {
       this.props.clickToEdit !== nextProps.clickToEdit ||
       this.props.dbclickToEdit !== nextProps.dbclickToEdit ||
       !_.isEqual(this.props.style, nextProps.style) ||
-      !_.isEqual(this.props.column.formatExtraData, nextProps.column.formatExtraData) ||
+      !_.isEqual(
+        this.props.column.formatExtraData,
+        nextProps.column.formatExtraData
+      ) ||
       !_.isEqual(this.props.column.events, nextProps.column.events) ||
       !_.isEqual(this.props.column.attrs, nextProps.column.attrs) ||
       this.props.tabIndex !== nextProps.tabIndex;
@@ -45,14 +51,20 @@ class Cell extends eventDelegater(Component) {
   }
 
   createHandleEditingCell = originFunc => (e) => {
-    const { onStart, rowIndex, columnIndex, clickToEdit, dbclickToEdit } = this.props;
+    const {
+      onStart,
+      rowIndex,
+      columnIndex,
+      clickToEdit,
+      dbclickToEdit
+    } = this.props;
     if ((clickToEdit || dbclickToEdit) && _.isFunction(originFunc)) {
       originFunc(e);
     }
     if (onStart) {
       onStart(rowIndex, columnIndex);
     }
-  }
+  };
 
   render() {
     const {
@@ -66,11 +78,7 @@ class Cell extends eventDelegater(Component) {
       dbclickToEdit,
       ...rest
     } = this.props;
-    const {
-      dataField,
-      formatter,
-      formatExtraData
-    } = column;
+    const { dataField, formatter, formatExtraData } = column;
     const attrs = this.delegate({ ...rest });
     let content = column.isDummyField ? null : _.get(row, dataField);
 
@@ -84,9 +92,13 @@ class Cell extends eventDelegater(Component) {
       attrs.onDoubleClick = this.createHandleEditingCell(attrs.onDoubleClick);
     }
 
-    return (
+    return column.isRowHeader ? (
+      <th { ...attrs }>
+        {typeof content === 'boolean' ? `${content}` : content}
+      </th>
+    ) : (
       <td { ...attrs }>
-        { typeof content === 'boolean' ? `${content}` : content }
+        {typeof content === 'boolean' ? `${content}` : content}
       </td>
     );
   }

--- a/packages/react-bootstrap-table2/src/row-expand/expand-cell.js
+++ b/packages/react-bootstrap-table2/src/row-expand/expand-cell.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 export default class ExpandCell extends Component {
   static propTypes = {
     rowKey: PropTypes.any,
+    isRowHeader: PropTypes.bool,
     expanded: PropTypes.bool.isRequired,
     expandable: PropTypes.bool.isRequired,
     onRowExpand: PropTypes.func.isRequired,
@@ -24,6 +25,7 @@ export default class ExpandCell extends Component {
 
   shouldComponentUpdate(nextProps) {
     const shouldUpdate =
+      this.props.isRowHeader !== nextProps.isRowHeader ||
       this.props.rowIndex !== nextProps.rowIndex ||
       this.props.expanded !== nextProps.expanded ||
       this.props.rowKey !== nextProps.rowKey ||
@@ -39,20 +41,28 @@ export default class ExpandCell extends Component {
   }
 
   render() {
-    const { expanded, expandable, expandColumnRenderer, tabIndex, rowKey } = this.props;
+    const {
+      expanded, expandable, expandColumnRenderer, tabIndex, rowKey, isRowHeader
+    } = this.props;
     const attrs = {};
     if (tabIndex !== -1) attrs.tabIndex = tabIndex;
-
-    return (
+    const cellContents = expandColumnRenderer ? expandColumnRenderer({
+      expandable,
+      expanded,
+      rowKey
+    }) : (expandable ? (expanded ? '(-)' : '(+)') : '');
+    return (isRowHeader ? (
+      <th className="expand-cell" onClick={ this.handleClick } { ...attrs }>
+        {
+          cellContents
+        }
+      </th>
+    ) : (
       <td className="expand-cell" onClick={ this.handleClick } { ...attrs }>
         {
-          expandColumnRenderer ? expandColumnRenderer({
-            expandable,
-            expanded,
-            rowKey
-          }) : (expandable ? (expanded ? '(-)' : '(+)') : '')
+          cellContents
         }
       </td>
-    );
+    ));
   }
 }

--- a/packages/react-bootstrap-table2/src/row-selection/selection-cell.js
+++ b/packages/react-bootstrap-table2/src/row-selection/selection-cell.js
@@ -12,6 +12,7 @@ export default class SelectionCell extends Component {
   static propTypes = {
     mode: PropTypes.string.isRequired,
     rowKey: PropTypes.any,
+    isRowHeader: PropTypes.bool,
     selected: PropTypes.bool,
     onRowSelect: PropTypes.func,
     disabled: PropTypes.bool,
@@ -29,6 +30,7 @@ export default class SelectionCell extends Component {
 
   shouldComponentUpdate(nextProps) {
     const shouldUpdate =
+      this.props.isRowHeader !== nextProps.isRowHeader ||
       this.props.rowIndex !== nextProps.rowIndex ||
       this.props.selected !== nextProps.selected ||
       this.props.disabled !== nextProps.disabled ||
@@ -62,6 +64,7 @@ export default class SelectionCell extends Component {
     const {
       rowKey,
       mode: inputType,
+      isRowHeader,
       selected,
       disabled,
       tabIndex,
@@ -81,31 +84,37 @@ export default class SelectionCell extends Component {
         rowKey
       }) :
       selectColumnStyle;
-
+    const cellContents = bootstrap4 => (selectionRenderer ? selectionRenderer({
+      mode: inputType,
+      checked: selected,
+      disabled,
+      rowIndex,
+      rowKey
+    }) : (
+      <input
+        type={ inputType }
+        checked={ selected }
+        disabled={ disabled }
+        className={ bootstrap4 ? 'selection-input-4' : '' }
+        onChange={ () => {} }
+      />
+    ));
     return (
       <BootstrapContext.Consumer>
         {
-          ({ bootstrap4 }) => (
+          ({ bootstrap4 }) => (isRowHeader ? (
+            <th className="selection-cell" onClick={ this.handleClick } { ...attrs }>
+              {
+                cellContents(bootstrap4)
+              }
+            </th>
+          ) : (
             <td className="selection-cell" onClick={ this.handleClick } { ...attrs }>
               {
-                selectionRenderer ? selectionRenderer({
-                  mode: inputType,
-                  checked: selected,
-                  disabled,
-                  rowIndex,
-                  rowKey
-                }) : (
-                  <input
-                    type={ inputType }
-                    checked={ selected }
-                    disabled={ disabled }
-                    className={ bootstrap4 ? 'selection-input-4' : '' }
-                    onChange={ () => {} }
-                  />
-                )
+                cellContents(bootstrap4)
               }
             </td>
-          )
+          ))
         }
       </BootstrapContext.Consumer>
     );

--- a/packages/react-bootstrap-table2/test/cell.test.js
+++ b/packages/react-bootstrap-table2/test/cell.test.js
@@ -45,6 +45,21 @@ describe('Cell', () => {
       expect(wrapper.text()).toEqual(aRowWithBoolValue[column.dataField].toString());
     });
   });
+  describe('when isRowHeader is true', () => {
+    const column = {
+      dataField: 'id',
+      text: 'ID',
+      isRowHeader: true
+    };
+
+    beforeEach(() => {
+      wrapper = shallow(<Cell row={ row } columnIndex={ 1 } rowIndex={ 1 } column={ column } />);
+    });
+
+    it('should render as a <TH>', () => {
+      expect(wrapper.first().type()).toEqual('th');
+    });
+  });
 
   describe('when column.formatter prop is defined', () => {
     const rowIndex = 1;

--- a/packages/react-bootstrap-table2/test/row-selection/selection-cell.test.js
+++ b/packages/react-bootstrap-table2/test/row-selection/selection-cell.test.js
@@ -248,6 +248,25 @@ describe('<SelectionCell />', () => {
       expect(wrapper.find('input').get(0).props.checked).toBe(selected);
       expect(toJson(wrapper)).toMatchSnapshot();
     });
+    describe('when isRowHeader prop give as true', () => {
+      beforeEach(() => {
+        wrapper = shallowWithContext(
+          <SelectionCell
+            rowKey={ 1 }
+            mode={ mode }
+            rowIndex={ rowIndex }
+            selected={ selected }
+            isRowHeader
+          />,
+          { bootstrap4: false }
+        );
+      });
+
+      it('should render at a <TH>', () => {
+        expect(wrapper.first().type()).toEqual('th');
+      });
+    });
+
 
     describe('when disabled prop give as true', () => {
       beforeEach(() => {


### PR DESCRIPTION
Allow columns to be rendered as TH, incl. selection and expansion cols

This will allow accessible association of headers via scope and/or headers attributes as recommended in WCAG 2.0
https://www.w3.org/TR/WCAG20-TECHS/H63.html
https://www.w3.org/TR/WCAG20-TECHS/H43.html

and also allows sticky 1st column styling
https://css-tricks.com/a-table-with-both-a-sticky-header-and-a-sticky-first-column/