### PR TITLE
Optimized string column sort (comparator + splitNested)

### DIFF
--- a/packages/react-bootstrap-table2/src/store/sort.js
+++ b/packages/react-bootstrap-table2/src/store/sort.js
@@ -4,14 +4,13 @@
 import _ from '../utils';
 import Const from '../const';
 
+const collator = new Intl.Collator();
 function comparator(a, b) {
-  let result;
   if (typeof b === 'string') {
-    result = b.localeCompare(a);
+    return collator.compare(a, b);
   } else {
-    result = a > b ? -1 : ((a < b) ? 1 : 0);
+    return a > b ? -1 : ((a < b) ? 1 : 0);
   }
-  return result;
 }
 
 export const sort = (data, sortOrder, { dataField, sortFunc, sortValue }) => {

--- a/packages/react-bootstrap-table2/src/utils.js
+++ b/packages/react-bootstrap-table2/src/utils.js
@@ -56,8 +56,8 @@ function isEmptyObject(obj) {
   const hasOwnProperty = Object.prototype.hasOwnProperty;
   const keys = Object.keys(obj);
 
-  for (let i = 0; i < keys.length; i += 1) {
-    if (hasOwnProperty.call(obj, keys[i])) return false;
+  for (let key of keys) {
+    if (hasOwnProperty.call(obj, key)) return false;
   }
 
   return true;

--- a/packages/react-bootstrap-table2/src/utils.js
+++ b/packages/react-bootstrap-table2/src/utils.js
@@ -4,11 +4,9 @@
 import _ from 'underscore';
 
 function splitNested(str) {
-  return [str]
-    .join('.')
-    .replace(/\[/g, '.')
-    .replace(/\]/g, '')
-    .split('.');
+  return str
+    .replace(']', '')
+    .split(/\[\./);
 }
 
 function contains(list, value) {


### PR DESCRIPTION
I've started experiencing really bad delay when changing page in my table whenever sorting by a string value column. I found the `splitNested` function to be the culprit. See 2 perf screenshots below
| ![SplitNested is slow 1](https://user-images.githubusercontent.com/1350584/118911433-2eb3d300-b8f4-11eb-92c3-16f9dbed12d5.png) | ![SplitNested is slow 2](https://user-images.githubusercontent.com/1350584/118911512-49864780-b8f4-11eb-9601-a2a79d71aa94.png) |
| - | - |

It seems to be doing some useless actions, like joining on an array of 1 string and replacing text in multiple iterations.
I also did my best to optimize the regex without affecting functionality.
Here are some performance comparisons from JSBench.Me:
![splitNested Optimisation test results](https://user-images.githubusercontent.com/1350584/118911897-f1037a00-b8f4-11eb-906c-28680a8f11c3.png)

And the new real-world performance results:
![splitNested Optimized results](https://user-images.githubusercontent.com/1350584/118911934-fd87d280-b8f4-11eb-84bb-6f18ed09bc1f.png)

Finally, I've used a better string comparison for very large array of strings. namely `Intl.Collator` instead of `localeCompare`.
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#performance
(I haven't yet recorded performance comparison)