### PR TITLE
Allow customized Headers by injection of additional header rows

### DIFF
--- a/packages/react-bootstrap-table2/src/bootstrap-table.js
+++ b/packages/react-bootstrap-table2/src/bootstrap-table.js
@@ -91,6 +91,7 @@ class BootstrapTable extends PropsBaseResolver(Component) {
       <div className={ tableWrapperClass }>
         <table id={ id } className={ tableClass }>
           { tableCaption }
+          {this.props.preHeader}
           <Header
             columns={ columns }
             className={ this.props.headerClasses }
@@ -105,7 +106,10 @@ class BootstrapTable extends PropsBaseResolver(Component) {
             selectRow={ selectRow }
             expandRow={ expandRow }
             filterPosition={ filterPosition }
+            preHeaderRow={ this.props.preHeaderRow }
+            postHeaderRow={ this.props.postHeaderRow }
           />
+          {this.props.postHeader}
           {hasFilters && filterPosition !== Const.FILTERS_POSITION_INLINE && (
             <Filters
               columns={ columns }
@@ -255,7 +259,9 @@ BootstrapTable.propTypes = {
     searchText: PropTypes.string,
     searchContext: PropTypes.func
   }),
-  setDependencyModules: PropTypes.func
+  setDependencyModules: PropTypes.func,
+  preHeaderRow: PropTypes.node,
+  postHeaderRow: PropTypes.node
 };
 
 BootstrapTable.defaultProps = {

--- a/packages/react-bootstrap-table2/src/header.js
+++ b/packages/react-bootstrap-table2/src/header.js
@@ -23,7 +23,9 @@ const Header = (props) => {
     onExternalFilter,
     filterPosition,
     globalSortCaret,
-    wrapperClasses
+    wrapperClasses,
+    preHeaderRow,
+    postHeaderRow
   } = props;
 
   let SelectionHeaderCellComp = () => null;
@@ -82,9 +84,11 @@ const Header = (props) => {
 
   return (
     <thead className={ wrapperClasses }>
+      {preHeaderRow}
       <tr className={ className }>
         { childrens }
       </tr>
+      {postHeaderRow}
     </thead>
   );
 };
@@ -106,7 +110,14 @@ Header.propTypes = {
     Const.FILTERS_POSITION_TOP,
     Const.FILTERS_POSITION_INLINE,
     Const.FILTERS_POSITION_BOTTOM
-  ])
+  ]),
+  preHeaderRow: PropTypes.node,
+  postHeaderRow: PropTypes.node
+};
+
+Header.defaultProps = {
+  preHeaderRow: null,
+  postHeaderRow: null
 };
 
 export default Header;


### PR DESCRIPTION
Allow injecting additional thead rows before and after the generated header row.

Valid tables can have a multiple tbody elements but only a single thead and tfoot. Therefore additional rows need to be injected into the exisiting Header component.